### PR TITLE
feat(create): add branch/<name> format support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ program
 program
   .command('create <project> <branch>')
   .description(
-    'Create a new worktree and Obsidian note\nBranch format: feature/<name>, bug/<name>, or pr/<number>',
+    'Create a new worktree and Obsidian note\nBranch format: feature/<name>, bug/<name>, branch/<name>, or pr/<number>',
   )
   .action(async (project, branch) => {
     try {
@@ -79,7 +79,7 @@ program
 program
   .command('clone <repo-url> [branch]')
   .description(
-    'Clone a repository and optionally create a worktree\nBranch format: feature/<name>, bug/<name>, or pr/<number>',
+    'Clone a repository and optionally create a worktree\nBranch format: feature/<name>, bug/<name>, branch/<name>, or pr/<number>',
   )
   .option('--upstream <url>', 'Upstream repository URL (e.g., for a fork)')
   .action(async (repoUrl, branch, options) => {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -43,6 +43,9 @@ export async function createCommand(project: string, branchArg: string): Promise
 
   if (branchArg.startsWith('feature/') || branchArg.startsWith('bug/')) {
     branch = branchArg;
+  } else if (branchArg.startsWith('branch/')) {
+    // Extract branch name without prefix for git operations
+    branch = branchArg.slice(7); // Remove "branch/" prefix
   } else if (branchArg.startsWith('pr/')) {
     const prNumber = branchArg.slice(3);
     try {
@@ -63,7 +66,7 @@ export async function createCommand(project: string, branchArg: string): Promise
       process.exit(1);
     }
   } else {
-    console.error('❌ Unknown branch prefix. Use feature/, bug/, or pr/');
+    console.error('❌ Unknown branch prefix. Use feature/, bug/, branch/, or pr/');
     process.exit(1);
   }
 


### PR DESCRIPTION
- Add support for branch/<name> format that creates/fetches branch without prefix
- Worktree path still includes -branch- prefix for organization
- Git branch name uses only the name part (no prefix)
- Update CLI descriptions to include branch/ format