### PR TITLE
feat: cmux + herdr session backends (opt-in terminal multiplexers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,12 +298,22 @@ Edit `~/.ghwtrc.json`:
 
 **Terminal Configuration Options:**
 
-- `terminalMultiplexer`: `"tmux"` (default) or `"zellij"` - Which multiplexer to use for sessions
-- `terminalUI`: `"wezterm"` (default) or `"none"` - How to launch sessions
+- `terminalMultiplexer`: `"tmux"` (default), `"zellij"`, or `"cmux"` - Which multiplexer to use for sessions
+  - `"cmux"`: macOS-only, opt-in. cmux is a fused UI + multiplexer, so `terminalUI` is a **no-op** when this is selected (cmux _is_ the UI; ghwt never spawns wezterm/ghostty). Requires cmux >= 0.63.0 (tested against 0.64.x); ghwt probes `cmux ping` + `cmux version` at startup. Not auto-selected by `ghwt init` - set it explicitly.
+- `terminalUI`: `"wezterm"` (default) or `"none"` - How to launch sessions (ignored when `terminalMultiplexer: "cmux"`)
   - `"wezterm"`: Launch WezTerm with multiplexer inside (modern UI)
   - `"none"`: Launch multiplexer directly (native zellij UI or raw tmux)
 
 > **Note:** `ci-artifacts-config/` and `terminal-session-config/` directories are automatically resolved relative to `projectsRoot` and do not need to be configured.
+
+### cmux Integration (macOS, opt-in)
+
+With `terminalMultiplexer: "cmux"`, ghwt manages cmux workspaces via the `cmux` CLI only (arms-length: no linking/embedding). ghwt remains the brain (worktree lifecycle, metadata, CI intelligence); cmux is one optional body (rendering, attention UI). Workspaces are keyed by a ghwt-stamped title (`ghwt:<session-name>`), resolved fresh each call (nothing persisted). Session config `tabs`/`windows`/`panes` are flattened to cmux surfaces; `zellij_ui`/`start_suspended` have no cmux analog and are ignored, just as tmux ignores them.
+
+Two thin bridges:
+
+- **Notify bridge** - `ghwt sync` rings the worktree's cmux workspace (`cmux notify`) only on a _transition_ into needs-attention (failing PR/CI checks, uncommitted changes, or stale > 7 days), never on every sync. No-op for tmux/zellij.
+- **Sync hook bridge** - `ghwt install-sync-hook` idempotently installs a Claude Code `Stop` hook running `ghwt sync --this` (non-fatal). When Claude finishes a turn in a worktree, the worktree re-syncs and (with cmux selected) the workspace rings on a needs-attention transition. `ghwt install-sync-hook --uninstall` removes it. (cmux has no hook registry of its own - this is wired Claude-side.)
 
 ### CI Artifacts Configuration
 
@@ -555,6 +565,7 @@ src/
 - **Terminal Multiplexer** (one of):
   - `tmux` - Terminal multiplexer (default, for session persistence)
   - `zellij` - Terminal multiplexer (alternative, set `terminalMultiplexer: "zellij"` in config)
+  - `cmux` - **macOS-only**, opt-in fused UI + multiplexer (set `terminalMultiplexer: "cmux"`). Minimum supported **v0.63.0**, tested against **v0.64.x**. See https://cmux.com. Arms-length integration via the `cmux` CLI only.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -298,9 +298,10 @@ Edit `~/.ghwtrc.json`:
 
 **Terminal Configuration Options:**
 
-- `terminalMultiplexer`: `"tmux"` (default), `"zellij"`, or `"cmux"` - Which multiplexer to use for sessions
+- `terminalMultiplexer`: `"tmux"` (default), `"zellij"`, `"cmux"`, or `"herdr"` - Which multiplexer to use for sessions
   - `"cmux"`: macOS-only, opt-in. cmux is a fused UI + multiplexer, so `terminalUI` is a **no-op** when this is selected (cmux _is_ the UI; ghwt never spawns wezterm/ghostty). Requires cmux >= 0.63.0 (tested against 0.64.x); ghwt probes `cmux ping` + `cmux version` at startup. **Also requires cmux's external CLI/socket access to be enabled** (see "External CLI access" below) - by default cmux refuses connections from processes it did not spawn. Not auto-selected by `ghwt init` - set it explicitly.
-- `terminalUI`: `"wezterm"` (default) or `"none"` - How to launch sessions (ignored when `terminalMultiplexer: "cmux"`)
+  - `"herdr"`: Linux/macOS, opt-in. herdr is a TUI multiplexer, so `terminalUI` **is** honored (ghwt launches herdr inside wezterm/ghostty, like tmux/zellij). Requires herdr >= 0.5.10 and its background server already running; ghwt probes `herdr --version` + `herdr session list --json` at startup and fails fast (it does **not** auto-spawn herdr's server - run `herdr` once yourself). Not auto-selected by `ghwt init` - set it explicitly.
+- `terminalUI`: `"wezterm"` (default) or `"none"` - How to launch sessions (ignored when `terminalMultiplexer: "cmux"`; honored for `"herdr"`)
   - `"wezterm"`: Launch WezTerm with multiplexer inside (modern UI)
   - `"none"`: Launch multiplexer directly (native zellij UI or raw tmux)
 
@@ -316,6 +317,14 @@ Two thin bridges:
 
 - **Notify bridge** - `ghwt sync` rings the worktree's cmux workspace (`cmux notify`) only on a _transition_ into needs-attention (failing PR/CI checks, uncommitted changes, or stale > 7 days), never on every sync. No-op for tmux/zellij.
 - **Sync hook bridge** - `ghwt install-sync-hook` idempotently installs a Claude Code `Stop` hook running `ghwt sync --this` (non-fatal). When Claude finishes a turn in a worktree, the worktree re-syncs and (with cmux selected) the workspace rings on a needs-attention transition. `ghwt install-sync-hook --uninstall` removes it. (cmux has no hook registry of its own - this is wired Claude-side.)
+
+### herdr Integration (Linux/macOS, opt-in)
+
+With `terminalMultiplexer: "herdr"`, ghwt manages [herdr](https://herdr.dev) workspaces via the `herdr` CLI only (arms-length: no linking; herdr is AGPL-3.0, but shelling out to a separate binary is not linking and does not affect ghwt's MIT license). ghwt remains the brain (worktree lifecycle, metadata, CI intelligence); herdr is one optional body. Each worktree maps to one herdr **workspace**, labelled `ghwt:<session-name>` and resolved by label each call (herdr ids are not stable across server restarts; nothing is persisted). Session config `tabs`/`windows`/`panes` are flattened to herdr **panes** - each ghwt pane becomes one pane via `pane split --cwd` + `pane run`. `zellij_ui`/`start_suspended` have no herdr analog and are ignored, just as tmux/cmux ignore them.
+
+Unlike cmux, herdr is a far thinner adapter: `workspace create` returns the workspace + root pane ids directly (no title-resolve round-trip), `pane run` executes commands with no shell-not-ready race, `pane split --cwd` sets per-pane cwd and targets a specific pane (no focus/`cd` hacks), herdr exits non-zero with a structured `{"error":...}` on failure (no exit-0 output sniffing), and its socket is the documented interface for external drivers (no cmux-style external-access wall). herdr is a TUI multiplexer like tmux/zellij, so `terminalUI` is honored (ghwt launches `herdr` inside wezterm/ghostty/none with the workspace pre-focused).
+
+> **No notify bridge.** herdr exposes no external notification trigger (no `herdr notify`); it detects per-pane agent state itself and self-notifies. So the herdr backend deliberately omits `notify` - the sync notify bridge no-ops for herdr exactly as it does for tmux/zellij. herdr's own agent-state detection (idle/working/blocked) is the intended attention signal; wiring it into ghwt's needs-attention model is a planned follow-up, not part of this backend.
 
 ### CI Artifacts Configuration
 
@@ -568,6 +577,7 @@ src/
   - `tmux` - Terminal multiplexer (default, for session persistence)
   - `zellij` - Terminal multiplexer (alternative, set `terminalMultiplexer: "zellij"` in config)
   - `cmux` - **macOS-only**, opt-in fused UI + multiplexer (set `terminalMultiplexer: "cmux"`). Minimum supported **v0.63.0**, tested against **v0.64.x**. See https://cmux.com. Arms-length integration via the `cmux` CLI only. **Requires cmux's external CLI/socket access setting enabled** (cmux blocks externally-spawned callers by default; no password bypass - [manaflow-ai/cmux#1864](https://github.com/manaflow-ai/cmux/issues/1864)).
+  - `herdr` - **Linux/macOS**, opt-in TUI multiplexer (set `terminalMultiplexer: "herdr"`). Minimum supported **v0.5.10** (validated against server protocol 6). See https://herdr.dev. Arms-length integration via the `herdr` CLI only; requires herdr's background server already running (ghwt does not auto-spawn it). `terminalUI` is honored (herdr runs inside wezterm/ghostty like tmux/zellij).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Edit `~/.ghwtrc.json`:
 **Terminal Configuration Options:**
 
 - `terminalMultiplexer`: `"tmux"` (default), `"zellij"`, or `"cmux"` - Which multiplexer to use for sessions
-  - `"cmux"`: macOS-only, opt-in. cmux is a fused UI + multiplexer, so `terminalUI` is a **no-op** when this is selected (cmux _is_ the UI; ghwt never spawns wezterm/ghostty). Requires cmux >= 0.63.0 (tested against 0.64.x); ghwt probes `cmux ping` + `cmux version` at startup. Not auto-selected by `ghwt init` - set it explicitly.
+  - `"cmux"`: macOS-only, opt-in. cmux is a fused UI + multiplexer, so `terminalUI` is a **no-op** when this is selected (cmux _is_ the UI; ghwt never spawns wezterm/ghostty). Requires cmux >= 0.63.0 (tested against 0.64.x); ghwt probes `cmux ping` + `cmux version` at startup. **Also requires cmux's external CLI/socket access to be enabled** (see "External CLI access" below) - by default cmux refuses connections from processes it did not spawn. Not auto-selected by `ghwt init` - set it explicitly.
 - `terminalUI`: `"wezterm"` (default) or `"none"` - How to launch sessions (ignored when `terminalMultiplexer: "cmux"`)
   - `"wezterm"`: Launch WezTerm with multiplexer inside (modern UI)
   - `"none"`: Launch multiplexer directly (native zellij UI or raw tmux)
@@ -308,7 +308,9 @@ Edit `~/.ghwtrc.json`:
 
 ### cmux Integration (macOS, opt-in)
 
-With `terminalMultiplexer: "cmux"`, ghwt manages cmux workspaces via the `cmux` CLI only (arms-length: no linking/embedding). ghwt remains the brain (worktree lifecycle, metadata, CI intelligence); cmux is one optional body (rendering, attention UI). Workspaces are keyed by a ghwt-stamped title (`ghwt:<session-name>`), resolved fresh each call (nothing persisted). Session config `tabs`/`windows`/`panes` are flattened to cmux surfaces; `zellij_ui`/`start_suspended` have no cmux analog and are ignored, just as tmux ignores them.
+With `terminalMultiplexer: "cmux"`, ghwt manages cmux workspaces via the `cmux` CLI only (arms-length: no linking/embedding). ghwt remains the brain (worktree lifecycle, metadata, CI intelligence); cmux is one optional body (rendering, attention UI). Workspaces are keyed by a ghwt-stamped title (`ghwt:<session-name>`), resolved fresh each call (nothing persisted). Session config `tabs`/`windows`/`panes` are flattened to cmux **panes** - each ghwt pane becomes one cmux pane (a live terminal). cmux _surfaces_ are deliberately not used: `new-surface` stacks non-live views inside a single pane and only the active one accepts input, so panes (`new-split`) are the addressable terminal unit. `zellij_ui`/`start_suspended` have no cmux analog and are ignored, just as tmux ignores them.
+
+> **External CLI access (required).** cmux's control socket only accepts connections from processes cmux itself spawned ("Access denied - only processes started inside cmux can connect"). ghwt drives cmux from _outside_ its terminals (it creates the workspace before any cmux terminal exists), so the cmux backend **requires cmux's external CLI/socket access setting to be enabled**. There is no password bypass ([manaflow-ai/cmux#1864](https://github.com/manaflow-ai/cmux/issues/1864) is an open, unimplemented request). If it is not enabled, ghwt fails fast with an actionable message naming the setting (it does **not** misreport this as "cmux not installed"). Without that setting the cmux backend cannot function; tmux/zellij are unaffected.
 
 Two thin bridges:
 
@@ -565,7 +567,7 @@ src/
 - **Terminal Multiplexer** (one of):
   - `tmux` - Terminal multiplexer (default, for session persistence)
   - `zellij` - Terminal multiplexer (alternative, set `terminalMultiplexer: "zellij"` in config)
-  - `cmux` - **macOS-only**, opt-in fused UI + multiplexer (set `terminalMultiplexer: "cmux"`). Minimum supported **v0.63.0**, tested against **v0.64.x**. See https://cmux.com. Arms-length integration via the `cmux` CLI only.
+  - `cmux` - **macOS-only**, opt-in fused UI + multiplexer (set `terminalMultiplexer: "cmux"`). Minimum supported **v0.63.0**, tested against **v0.64.x**. See https://cmux.com. Arms-length integration via the `cmux` CLI only. **Requires cmux's external CLI/socket access setting enabled** (cmux blocks externally-spawned callers by default; no password bypass - [manaflow-ai/cmux#1864](https://github.com/manaflow-ai/cmux/issues/1864)).
 
 ## Development
 

--- a/src/__tests__/lib/attention.unit.test.ts
+++ b/src/__tests__/lib/attention.unit.test.ts
@@ -27,6 +27,16 @@ describe('needsAttention truth table', () => {
     expect(needsAttention({ has_uncommitted_changes: true })).toBe(true);
   });
 
+  it('true when the agent is blocked (waiting on the human)', () => {
+    expect(needsAttention({ agent_status: 'blocked' })).toBe(true);
+  });
+
+  it('false for non-blocked agent states', () => {
+    for (const agent_status of ['idle', 'working', 'done', 'unknown']) {
+      expect(needsAttention({ agent_status })).toBe(false);
+    }
+  });
+
   it('true only past the staleness threshold', () => {
     expect(needsAttention({ days_since_activity: ATTENTION_STALE_DAYS })).toBe(false);
     expect(needsAttention({ days_since_activity: ATTENTION_STALE_DAYS + 1 })).toBe(true);

--- a/src/__tests__/lib/attention.unit.test.ts
+++ b/src/__tests__/lib/attention.unit.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest';
+import { needsAttention, ATTENTION_STALE_DAYS } from '../../lib/attention.js';
+import { notifyOnAttentionTransition } from '../../commands/sync.js';
+import { TerminalSessionManager } from '../../lib/terminal-session-base.js';
+
+describe('needsAttention truth table', () => {
+  it('false for a healthy worktree', () => {
+    expect(
+      needsAttention({
+        pr_checks: 'passing',
+        ci_checks: 'passing',
+        has_uncommitted_changes: false,
+        days_since_activity: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it('true when PR checks failing', () => {
+    expect(needsAttention({ pr_checks: 'failing' })).toBe(true);
+  });
+
+  it('true when CI checks failing', () => {
+    expect(needsAttention({ ci_checks: 'failing' })).toBe(true);
+  });
+
+  it('true when there are uncommitted changes', () => {
+    expect(needsAttention({ has_uncommitted_changes: true })).toBe(true);
+  });
+
+  it('true only past the staleness threshold', () => {
+    expect(needsAttention({ days_since_activity: ATTENTION_STALE_DAYS })).toBe(false);
+    expect(needsAttention({ days_since_activity: ATTENTION_STALE_DAYS + 1 })).toBe(true);
+  });
+
+  it('false on an empty/partial frontmatter', () => {
+    expect(needsAttention({})).toBe(false);
+  });
+});
+
+describe('notifyOnAttentionTransition', () => {
+  const makeManager = (withNotify: boolean) => {
+    const notify = vi.fn().mockResolvedValue(undefined);
+    const mgr = { notify: withNotify ? notify : undefined } as unknown as TerminalSessionManager;
+    return { mgr, notify };
+  };
+
+  it('fires on a false -> true transition', async () => {
+    const { mgr, notify } = makeManager(true);
+    await notifyOnAttentionTransition(
+      mgr,
+      'proj-branch',
+      'proj',
+      'branch',
+      { pr_checks: 'passing' },
+      { pr_checks: 'failing' },
+    );
+    expect(notify).toHaveBeenCalledWith('proj-branch', 'ghwt: needs attention', 'proj/branch');
+  });
+
+  it('does not fire when already needing attention (no transition)', async () => {
+    const { mgr, notify } = makeManager(true);
+    await notifyOnAttentionTransition(
+      mgr,
+      'proj-branch',
+      'proj',
+      'branch',
+      { pr_checks: 'failing' },
+      { pr_checks: 'failing' },
+    );
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('does not fire on a true -> false transition', async () => {
+    const { mgr, notify } = makeManager(true);
+    await notifyOnAttentionTransition(
+      mgr,
+      'proj-branch',
+      'proj',
+      'branch',
+      { has_uncommitted_changes: true },
+      { has_uncommitted_changes: false },
+    );
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('merges partial updates over prior frontmatter (a sparse delta cannot erase prior attention)', async () => {
+    const { mgr, notify } = makeManager(true);
+    // Prior already needs attention via ci_checks; the sync delta only carries
+    // pr_checks. Merge must keep ci_checks=failing -> still attention, no
+    // false->true transition, so no notification.
+    await notifyOnAttentionTransition(
+      mgr,
+      'proj-branch',
+      'proj',
+      'branch',
+      { ci_checks: 'failing' },
+      { pr_checks: 'passing' },
+    );
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for backends without notify (tmux/zellij)', async () => {
+    const { mgr } = makeManager(false);
+    await expect(
+      notifyOnAttentionTransition(
+        mgr,
+        'proj-branch',
+        'proj',
+        'branch',
+        { pr_checks: 'passing' },
+        { pr_checks: 'failing' },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('swallows notify errors (advisory only)', async () => {
+    const notify = vi.fn().mockRejectedValue(new Error('cmux down'));
+    const mgr = { notify } as unknown as TerminalSessionManager;
+    await expect(
+      notifyOnAttentionTransition(
+        mgr,
+        'p-b',
+        'p',
+        'b',
+        { ci_checks: 'passing' },
+        { ci_checks: 'failing' },
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/lib/sync-hook.unit.test.ts
+++ b/src/__tests__/lib/sync-hook.unit.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+let fakeHome: string;
+
+vi.mock('os', async (importActual) => {
+  const actual = await importActual<typeof import('os')>();
+  return { ...actual, homedir: () => fakeHome };
+});
+
+import {
+  installSyncHook,
+  uninstallSyncHook,
+  getClaudeSettingsPath,
+  SYNC_HOOK_COMMAND,
+} from '../../lib/sync-hook.js';
+
+function readSettings() {
+  return JSON.parse(readFileSync(getClaudeSettingsPath(), 'utf-8'));
+}
+
+describe('sync-hook installer', () => {
+  beforeEach(() => {
+    fakeHome = mkdtempSync(join(tmpdir(), 'ghwt-hook-'));
+  });
+  afterEach(() => {
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it('creates settings.json with the Stop hook when none exists', () => {
+    const { created } = installSyncHook();
+    expect(created).toBe(true);
+    expect(readSettings().hooks.Stop).toEqual([
+      { hooks: [{ type: 'command', command: SYNC_HOOK_COMMAND }] },
+    ]);
+  });
+
+  it('is idempotent (no duplicate entry on repeated install)', () => {
+    installSyncHook();
+    installSyncHook();
+    const stop = readSettings().hooks.Stop;
+    const ours = stop.flatMap((g: { hooks: { command: string }[] }) =>
+      g.hooks.filter((h) => h.command === SYNC_HOOK_COMMAND),
+    );
+    expect(ours).toHaveLength(1);
+  });
+
+  it('preserves unrelated settings and other Stop hooks', () => {
+    mkdirSync(join(fakeHome, '.claude'), { recursive: true });
+    writeFileSync(
+      getClaudeSettingsPath(),
+      JSON.stringify({
+        env: { FOO: 'bar' },
+        hooks: { Stop: [{ hooks: [{ type: 'command', command: 'other-tool' }] }] },
+      }),
+    );
+
+    installSyncHook();
+    const s = readSettings();
+    expect(s.env).toEqual({ FOO: 'bar' });
+    expect(s.hooks.Stop).toContainEqual({
+      hooks: [{ type: 'command', command: 'other-tool' }],
+    });
+    expect(s.hooks.Stop).toContainEqual({
+      hooks: [{ type: 'command', command: SYNC_HOOK_COMMAND }],
+    });
+  });
+
+  it('uninstall removes only our hook and drops empty Stop', () => {
+    installSyncHook();
+    uninstallSyncHook();
+    const s = readSettings();
+    expect(s.hooks.Stop).toBeUndefined();
+  });
+
+  it('uninstall keeps other Stop hooks intact', () => {
+    mkdirSync(join(fakeHome, '.claude'), { recursive: true });
+    writeFileSync(
+      getClaudeSettingsPath(),
+      JSON.stringify({
+        hooks: { Stop: [{ hooks: [{ type: 'command', command: 'other-tool' }] }] },
+      }),
+    );
+    installSyncHook();
+    uninstallSyncHook();
+    expect(readSettings().hooks.Stop).toEqual([
+      { hooks: [{ type: 'command', command: 'other-tool' }] },
+    ]);
+  });
+
+  it('throws a clear error on malformed settings.json', () => {
+    mkdirSync(join(fakeHome, '.claude'), { recursive: true });
+    writeFileSync(getClaudeSettingsPath(), '{ not json');
+    expect(() => installSyncHook()).toThrow(/invalid JSON/);
+  });
+});

--- a/src/__tests__/lib/terminal-session-cmux.integration.test.ts
+++ b/src/__tests__/lib/terminal-session-cmux.integration.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { execa } from 'execa';
+import { CmuxSessionManager } from '../../lib/terminal-session-cmux.js';
+import type { SessionConfig } from '../../lib/terminal-session-base.js';
+
+/**
+ * Real-cmux integration test (macOS + cmux reachable only).
+ *
+ * The mocked unit tests asserted a contract that did not survive contact with
+ * real cmux (send --surface is rejected; new-surface stacks non-live views).
+ * This exercise drives the actual `cmux` binary end to end: create a workspace,
+ * verify the pre/pane cascade really executed via read-screen, then tear down.
+ *
+ * Self-gating: skipped unless on darwin AND `cmux ping` succeeds without an
+ * auth-refusal/error envelope (manaflow-ai/cmux#1864 - external CLI access
+ * requires cmux's external-access setting). Mirrors how other *.integration
+ * tests use real resources but stay green when the resource is absent.
+ */
+
+async function cmuxReachable(): Promise<boolean> {
+  if (process.platform !== 'darwin') return false;
+  try {
+    const r = await execa('cmux', ['ping'], { reject: false });
+    const out = `${r.stdout ?? ''}\n${r.stderr ?? ''}`;
+    if (/Access denied|Failed to write to socket|Broken pipe|(^|\n)\s*Error:/i.test(out)) {
+      return false;
+    }
+    return /PONG/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
+describe('cmux integration (real cmux, macOS, socket reachable)', () => {
+  const createdRefs: string[] = [];
+
+  afterAll(async () => {
+    for (const ref of createdRefs) {
+      await execa('cmux', ['close-workspace', '--workspace', ref], { reject: false }).catch(
+        () => {},
+      );
+    }
+  });
+
+  it('createSession builds a ghwt-titled workspace whose pane actually runs the cascade', async (ctx) => {
+    if (!(await cmuxReachable())) {
+      ctx.skip(); // not darwin / cmux unreachable / external access refused
+      return;
+    }
+    const mgr = new CmuxSessionManager(undefined, false);
+    const sessionName = `itest-${Date.now()}`;
+    const config: SessionConfig = {
+      name: 'itest',
+      pre: ['echo GHWT_PRE_OK'],
+      windows: [{ name: 'w', panes: ['echo GHWT_PANE_OK'] }],
+    };
+    // A little headroom for the shell-not-ready race (cmux#2538).
+    process.env.GHWT_CMUX_SURFACE_DELAY_MS = '800';
+
+    await mgr.createSession(sessionName, config, process.cwd(), 'proj', 'branch');
+
+    const { stdout } = await execa('cmux', ['list-workspaces', '--json']);
+    const ws = (JSON.parse(stdout).workspaces as Array<{ ref: string; title?: string }>).find(
+      (w) => w.title === `ghwt:${sessionName}`,
+    );
+    expect(ws, 'ghwt-titled workspace should exist after createSession').toBeTruthy();
+    createdRefs.push(ws!.ref);
+
+    expect(await mgr.sessionExists(sessionName)).toBe(true);
+
+    // Let the shell render the echoed output, then assert it really ran.
+    await new Promise((r) => setTimeout(r, 1500));
+    const screen = await execa('cmux', ['read-screen', '--workspace', ws!.ref]);
+    expect(screen.stdout).toMatch(/GHWT_PRE_OK/);
+    expect(screen.stdout).toMatch(/GHWT_PANE_OK/);
+
+    await mgr.killSession(sessionName);
+    expect(await mgr.sessionExists(sessionName)).toBe(false);
+    createdRefs.pop(); // already closed
+  }, 40000);
+});

--- a/src/__tests__/lib/terminal-session-cmux.unit.test.ts
+++ b/src/__tests__/lib/terminal-session-cmux.unit.test.ts
@@ -34,14 +34,19 @@ beforeEach(() => {
   workspacesJson = '[]';
   process.env.GHWT_CMUX_SURFACE_DELAY_MS = '0';
 
-  let surfaceN = 0;
+  // Pane model: a workspace is created with one initial pane (pane:1);
+  // each additional ghwt pane is a new-split that returns a fresh pane ref.
+  let paneN = 1;
   execaMock.mockImplementation(async (_bin: string, args: string[]) => {
     const sub = args[0];
     if (sub === 'list-workspaces') return { stdout: workspacesJson };
     if (sub === 'new-workspace') return { stdout: 'OK workspace:1' };
-    if (sub === 'new-surface' || sub === 'new-split') {
-      surfaceN += 1;
-      return { stdout: `OK surface:${surfaceN}` };
+    if (sub === 'list-panes') {
+      return { stdout: JSON.stringify({ panes: [{ ref: 'pane:1', index: 0, focused: true }] }) };
+    }
+    if (sub === 'new-split') {
+      paneN += 1;
+      return { stdout: JSON.stringify({ pane_ref: `pane:${paneN}` }) };
     }
     if (sub === 'version') return { stdout: 'cmux 0.64.1' };
     return { stdout: '' };
@@ -49,7 +54,7 @@ beforeEach(() => {
 });
 
 describe('CmuxSessionManager.createSession', () => {
-  it('emits ordered cmux calls: workspace, rename(title), surface, send cascade, split', async () => {
+  it('emits ordered cmux calls: workspace, rename(title), initial pane, focus+send cascade, split', async () => {
     const mgr = new CmuxSessionManager();
     const config: SessionConfig = {
       name: 'sample',
@@ -64,17 +69,22 @@ describe('CmuxSessionManager.createSession', () => {
       ['list-workspaces', '--json'],
       ['new-workspace', '--cwd', '/wt', '--json'],
       ['rename-workspace', '--workspace', 'workspace:1', 'ghwt:proj-branch'],
-      // window "editor" -> new surface (no initial surface ref returned)
-      ['new-surface', '--workspace', 'workspace:1', '--json'],
-      ['send', 'nvm use\n', '--surface', 'surface:1'],
-      ['send', 'vim\n', '--surface', 'surface:1'],
-      // pane 2 -> split off the window surface
-      ['new-split', 'right', '--surface', 'surface:1', '--json'],
-      ['send', 'nvm use\n', '--surface', 'surface:2'],
-      ['send', 'npm test\n', '--surface', 'surface:2'],
-      // window "shell" -> new surface, no command
-      ['new-surface', '--workspace', 'workspace:1', '--json'],
-      ['send', 'nvm use\n', '--surface', 'surface:3'],
+      // initial pane discovered from the freshly created workspace
+      ['list-panes', '--workspace', 'workspace:1', '--json'],
+      // editor pane 0 reuses the initial pane; send addressed by --workspace
+      // (send --surface is rejected by cmux even for live surfaces)
+      ['focus-pane', '--pane', 'pane:1', '--workspace', 'workspace:1'],
+      ['send', 'nvm use\n', '--workspace', 'workspace:1'],
+      ['send', 'vim\n', '--workspace', 'workspace:1'],
+      // editor pane 1 -> split (new pane), focus, cascade
+      ['new-split', 'right', '--workspace', 'workspace:1', '--json'],
+      ['focus-pane', '--pane', 'pane:2', '--workspace', 'workspace:1'],
+      ['send', 'nvm use\n', '--workspace', 'workspace:1'],
+      ['send', 'npm test\n', '--workspace', 'workspace:1'],
+      // window "shell" -> split (new pane), focus, cascade, no command
+      ['new-split', 'right', '--workspace', 'workspace:1', '--json'],
+      ['focus-pane', '--pane', 'pane:3', '--workspace', 'workspace:1'],
+      ['send', 'nvm use\n', '--workspace', 'workspace:1'],
     ]);
   });
 
@@ -89,8 +99,8 @@ describe('CmuxSessionManager.createSession', () => {
 
     const sends = cmuxCalls().filter((a) => a[0] === 'send');
     expect(sends).toEqual([
-      ['send', 'cd /wt/server\n', '--surface', 'surface:1'],
-      ['send', 'npm start\n', '--surface', 'surface:1'],
+      ['send', 'cd /wt/server\n', '--workspace', 'workspace:1'],
+      ['send', 'npm start\n', '--workspace', 'workspace:1'],
     ]);
   });
 
@@ -175,17 +185,19 @@ describe('CmuxSessionManager attach/kill resolve ref then map to cmux verbs', ()
   });
 });
 
-describe('createSession initial-surface reuse (new-workspace returns a surface)', () => {
-  it('reuses the workspace initial surface for window 0, allocates fresh after', async () => {
-    let surfaceN = 0;
+describe('createSession pane model (initial pane reuse + split + parsing)', () => {
+  it('reuses the workspace initial pane for window 0, splits a fresh pane after', async () => {
+    let paneN = 0;
     execaMock.mockImplementation(async (_bin: string, args: string[]) => {
       const sub = args[0];
       if (sub === 'list-workspaces') return { stdout: '[]' };
-      // new-workspace surfaces the initial surface ref alongside the workspace.
-      if (sub === 'new-workspace') return { stdout: 'OK workspace:1 surface:1' };
-      if (sub === 'new-surface' || sub === 'new-split') {
-        surfaceN += 1;
-        return { stdout: `OK surface:${100 + surfaceN}` };
+      if (sub === 'new-workspace') return { stdout: 'OK workspace:1' };
+      if (sub === 'list-panes') {
+        return { stdout: JSON.stringify({ panes: [{ ref: 'pane:1', index: 0 }] }) };
+      }
+      if (sub === 'new-split') {
+        paneN += 1;
+        return { stdout: JSON.stringify({ pane_ref: `pane:${100 + paneN}` }) };
       }
       return { stdout: '' };
     });
@@ -201,28 +213,36 @@ describe('createSession initial-surface reuse (new-workspace returns a surface)'
     await mgr.createSession('p-b', config, '/wt', 'p', 'b');
 
     const c = cmuxCalls();
-    // Window 0 reuses surface:1 (the initial surface) - no new-surface for it.
-    expect(c).toContainEqual(['send', 'echo a\n', '--surface', 'surface:1']);
-    // Window 1 allocates a fresh surface (first new-surface call).
-    const newSurfaceCalls = c.filter((a) => a[0] === 'new-surface');
-    expect(newSurfaceCalls).toEqual([['new-surface', '--workspace', 'workspace:1', '--json']]);
-    expect(c).toContainEqual(['send', 'echo b\n', '--surface', 'surface:101']);
+    // Window 0 reuses the initial pane:1 - no new-split for it.
+    expect(c).toContainEqual(['focus-pane', '--pane', 'pane:1', '--workspace', 'workspace:1']);
+    expect(c).toContainEqual(['send', 'echo a\n', '--workspace', 'workspace:1']);
+    // Window 1 splits a fresh pane (first and only new-split call).
+    const splitCalls = c.filter((a) => a[0] === 'new-split');
+    expect(splitCalls).toEqual([['new-split', 'right', '--workspace', 'workspace:1', '--json']]);
+    expect(c).toContainEqual(['focus-pane', '--pane', 'pane:101', '--workspace', 'workspace:1']);
+    expect(c).toContainEqual(['send', 'echo b\n', '--workspace', 'workspace:1']);
   });
 
-  it('parses --json surface_ref form (not just OK text)', async () => {
+  it('parses --json ref forms for new-workspace and new-split (not just OK text)', async () => {
     execaMock.mockImplementation(async (_bin: string, args: string[]) => {
       const sub = args[0];
       if (sub === 'list-workspaces') return { stdout: '[]' };
       if (sub === 'new-workspace')
         return { stdout: JSON.stringify({ workspace_ref: 'workspace:4' }) };
-      if (sub === 'new-surface') return { stdout: JSON.stringify({ surface_ref: 'surface:9' }) };
+      if (sub === 'list-panes') {
+        return { stdout: JSON.stringify({ panes: [{ ref: 'pane:7' }] }) };
+      }
+      if (sub === 'new-split') return { stdout: JSON.stringify({ pane_ref: 'pane:9' }) };
       return { stdout: '' };
     });
 
     const mgr = new CmuxSessionManager();
     await mgr.createSession(
       'p-b',
-      { name: 's', windows: [{ name: 'w', panes: ['ls'] }] },
+      {
+        name: 's',
+        windows: [{ name: 'w', panes: ['ls'] }, { name: 'x' }],
+      },
       '/wt',
       'p',
       'b',
@@ -230,8 +250,11 @@ describe('createSession initial-surface reuse (new-workspace returns a surface)'
 
     const c = cmuxCalls();
     expect(c).toContainEqual(['rename-workspace', '--workspace', 'workspace:4', 'ghwt:p-b']);
-    expect(c).toContainEqual(['new-surface', '--workspace', 'workspace:4', '--json']);
-    expect(c).toContainEqual(['send', 'ls\n', '--surface', 'surface:9']);
+    expect(c).toContainEqual(['list-panes', '--workspace', 'workspace:4', '--json']);
+    // window 0 reuses initial pane:7; window 1 splits -> pane:9 (json pane_ref)
+    expect(c).toContainEqual(['focus-pane', '--pane', 'pane:7', '--workspace', 'workspace:4']);
+    expect(c).toContainEqual(['send', 'ls\n', '--workspace', 'workspace:4']);
+    expect(c).toContainEqual(['focus-pane', '--pane', 'pane:9', '--workspace', 'workspace:4']);
   });
 });
 
@@ -269,6 +292,75 @@ describe('assertCmuxReady', () => {
       return { stdout: '' };
     });
     await expect(assertCmuxReady()).resolves.toBeUndefined();
+  });
+});
+
+describe('hardened cmux exec (cmux exits 0 on errors; stale refs misroute)', () => {
+  it('assertCmuxReady: broken-pipe auth refusal -> actionable #1864 message, not "install"', async () => {
+    execaMock.mockImplementation(async (_b: string, args: string[]) => {
+      if (args[0] === 'ping') {
+        return { stdout: '', stderr: 'Error: Failed to write to socket (Broken pipe, errno 32)' };
+      }
+      return { stdout: '' };
+    });
+    await expect(assertCmuxReady()).rejects.toThrow(/refusing external CLI access/);
+    await expect(assertCmuxReady()).rejects.toThrow(/cmux#1864/);
+  });
+
+  it('assertCmuxReady: "Access denied" classified as auth refusal (not unreachable)', async () => {
+    execaMock.mockImplementation(async (_b: string, args: string[]) => {
+      if (args[0] === 'ping') {
+        return { stdout: 'ERROR: Access denied — only processes started inside cmux can connect' };
+      }
+      return { stdout: '' };
+    });
+    await expect(assertCmuxReady()).rejects.toThrow(/refusing external CLI access/);
+  });
+
+  it('createSession: aborts when a fresh workspace reports no panes (misroute guard)', async () => {
+    execaMock.mockImplementation(async (_b: string, args: string[]) => {
+      const sub = args[0];
+      if (sub === 'list-workspaces') return { stdout: '[]' };
+      if (sub === 'new-workspace') return { stdout: 'OK workspace:1' };
+      if (sub === 'list-panes') return { stdout: JSON.stringify({ panes: [] }) };
+      return { stdout: '' };
+    });
+    const mgr = new CmuxSessionManager();
+    await expect(
+      mgr.createSession(
+        'p-b',
+        { name: 's', windows: [{ name: 'w', panes: ['ls'] }] },
+        '/wt',
+        'p',
+        'b',
+      ),
+    ).rejects.toThrow(/no panes|wrong workspace/);
+    // The guard must fire before any send could misroute.
+    expect(cmuxCalls().filter((a) => a[0] === 'send')).toEqual([]);
+  });
+
+  it('createSession: focus-pane "not_found" (exit 0) aborts instead of misrouting the send', async () => {
+    execaMock.mockImplementation(async (_b: string, args: string[]) => {
+      const sub = args[0];
+      if (sub === 'list-workspaces') return { stdout: '[]' };
+      if (sub === 'new-workspace') return { stdout: 'OK workspace:1' };
+      if (sub === 'list-panes') return { stdout: JSON.stringify({ panes: [{ ref: 'pane:1' }] }) };
+      // cmux returns errors on stdout with exit code 0:
+      if (sub === 'focus-pane') return { stdout: 'Error: not_found: Pane not found' };
+      return { stdout: '' };
+    });
+    const mgr = new CmuxSessionManager();
+    await expect(
+      mgr.createSession(
+        'p-b',
+        { name: 's', windows: [{ name: 'w', panes: ['ls'] }] },
+        '/wt',
+        'p',
+        'b',
+      ),
+    ).rejects.toThrow(/focus-pane failed|not_found/);
+    // Critical safety property: no command was sent anywhere.
+    expect(cmuxCalls().filter((a) => a[0] === 'send')).toEqual([]);
   });
 });
 

--- a/src/__tests__/lib/terminal-session-cmux.unit.test.ts
+++ b/src/__tests__/lib/terminal-session-cmux.unit.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// execa is mocked so no real cmux binary is invoked.
+const execaMock = vi.fn();
+vi.mock('execa', () => ({ execa: (...args: unknown[]) => execaMock(...args) }));
+
+import {
+  CmuxSessionManager,
+  parseCmuxVersion,
+  assertCmuxReady,
+} from '../../lib/terminal-session-cmux.js';
+import { SessionConfig } from '../../lib/terminal-session-base.js';
+
+type Call = [string, string[]];
+
+function calls(): Call[] {
+  return execaMock.mock.calls.map((c) => [c[0] as string, c[1] as string[]]);
+}
+
+function cmuxCalls(): string[][] {
+  return calls()
+    .filter(([bin]) => bin === 'cmux')
+    .map(([, args]) => args);
+}
+
+/**
+ * Default mock: empty workspace list, sequential surface refs.
+ * Tests override list-workspaces output via `workspacesJson`.
+ */
+let workspacesJson = '[]';
+
+beforeEach(() => {
+  execaMock.mockReset();
+  workspacesJson = '[]';
+  process.env.GHWT_CMUX_SURFACE_DELAY_MS = '0';
+
+  let surfaceN = 0;
+  execaMock.mockImplementation(async (_bin: string, args: string[]) => {
+    const sub = args[0];
+    if (sub === 'list-workspaces') return { stdout: workspacesJson };
+    if (sub === 'new-workspace') return { stdout: 'OK workspace:1' };
+    if (sub === 'new-surface' || sub === 'new-split') {
+      surfaceN += 1;
+      return { stdout: `OK surface:${surfaceN}` };
+    }
+    if (sub === 'version') return { stdout: 'cmux 0.64.1' };
+    return { stdout: '' };
+  });
+});
+
+describe('CmuxSessionManager.createSession', () => {
+  it('emits ordered cmux calls: workspace, rename(title), surface, send cascade, split', async () => {
+    const mgr = new CmuxSessionManager();
+    const config: SessionConfig = {
+      name: 'sample',
+      pre: ['nvm use'],
+      windows: [{ name: 'editor', panes: ['vim', 'npm test'] }, { name: 'shell' }],
+    };
+
+    await mgr.createSession('proj-branch', config, '/wt', 'proj', 'branch');
+
+    expect(cmuxCalls()).toEqual([
+      // sessionExists pre-check
+      ['list-workspaces', '--json'],
+      ['new-workspace', '--cwd', '/wt', '--json'],
+      ['rename-workspace', '--workspace', 'workspace:1', 'ghwt:proj-branch'],
+      // window "editor" -> new surface (no initial surface ref returned)
+      ['new-surface', '--workspace', 'workspace:1', '--json'],
+      ['send', 'nvm use\n', '--surface', 'surface:1'],
+      ['send', 'vim\n', '--surface', 'surface:1'],
+      // pane 2 -> split off the window surface
+      ['new-split', 'right', '--surface', 'surface:1', '--json'],
+      ['send', 'nvm use\n', '--surface', 'surface:2'],
+      ['send', 'npm test\n', '--surface', 'surface:2'],
+      // window "shell" -> new surface, no command
+      ['new-surface', '--workspace', 'workspace:1', '--json'],
+      ['send', 'nvm use\n', '--surface', 'surface:3'],
+    ]);
+  });
+
+  it('cd into window root only when it differs from worktree path', async () => {
+    const mgr = new CmuxSessionManager();
+    const config: SessionConfig = {
+      name: 'sample',
+      windows: [{ name: 'srv', root: 'server', panes: ['npm start'] }],
+    };
+
+    await mgr.createSession('p-b', config, '/wt', 'p', 'b');
+
+    const sends = cmuxCalls().filter((a) => a[0] === 'send');
+    expect(sends).toEqual([
+      ['send', 'cd /wt/server\n', '--surface', 'surface:1'],
+      ['send', 'npm start\n', '--surface', 'surface:1'],
+    ]);
+  });
+
+  it('skips creation when the workspace already exists', async () => {
+    workspacesJson = JSON.stringify([{ ref: 'workspace:9', title: 'ghwt:p-b' }]);
+    const mgr = new CmuxSessionManager();
+
+    await mgr.createSession('p-b', { name: 's', windows: [{ name: 'w' }] }, '/wt', 'p', 'b');
+
+    expect(cmuxCalls()).toEqual([['list-workspaces', '--json']]);
+  });
+});
+
+describe('CmuxSessionManager.sessionExists', () => {
+  it('matches by ghwt-stamped title and returns true', async () => {
+    workspacesJson = JSON.stringify([
+      { ref: 'workspace:2', title: 'ghwt:proj-branch', selected: false },
+      { ref: 'workspace:3', title: 'something-else' },
+    ]);
+    const mgr = new CmuxSessionManager();
+    expect(await mgr.sessionExists('proj-branch')).toBe(true);
+  });
+
+  it('returns false when no title matches', async () => {
+    workspacesJson = JSON.stringify([{ ref: 'workspace:2', title: 'ghwt:other' }]);
+    const mgr = new CmuxSessionManager();
+    expect(await mgr.sessionExists('proj-branch')).toBe(false);
+  });
+
+  it('throws on ambiguous multi-title match (never guesses)', async () => {
+    workspacesJson = JSON.stringify([
+      { ref: 'workspace:2', title: 'ghwt:proj-branch' },
+      { ref: 'workspace:5', title: 'ghwt:proj-branch' },
+    ]);
+    const mgr = new CmuxSessionManager();
+    await expect(mgr.sessionExists('proj-branch')).rejects.toThrow(/Ambiguous cmux workspace/);
+  });
+});
+
+describe('CmuxSessionManager attach/kill resolve ref then map to cmux verbs', () => {
+  it('attachToSession ensures app then select-workspace by ref', async () => {
+    workspacesJson = JSON.stringify([{ ref: 'workspace:7', title: 'ghwt:p-b' }]);
+    const mgr = new CmuxSessionManager();
+
+    await mgr.attachToSession('p-b', '/wt');
+
+    const c = cmuxCalls();
+    expect(c).toContainEqual(['ping']);
+    expect(c).toContainEqual(['select-workspace', '--workspace', 'workspace:7']);
+  });
+
+  it('killSession resolves ref then close-workspace', async () => {
+    workspacesJson = JSON.stringify([{ ref: 'workspace:7', title: 'ghwt:p-b' }]);
+    const mgr = new CmuxSessionManager();
+
+    await mgr.killSession('p-b');
+
+    expect(cmuxCalls()).toContainEqual(['close-workspace', '--workspace', 'workspace:7']);
+  });
+
+  it('killSession is a no-op when the workspace is absent', async () => {
+    const mgr = new CmuxSessionManager();
+    await mgr.killSession('p-b');
+    expect(cmuxCalls()).toEqual([['list-workspaces', '--json']]);
+  });
+
+  it('notify rings the resolved workspace with a title', async () => {
+    workspacesJson = JSON.stringify([{ ref: 'workspace:7', title: 'ghwt:p-b' }]);
+    const mgr = new CmuxSessionManager();
+
+    await mgr.notify('p-b', 'ghwt', 'needs attention');
+
+    expect(cmuxCalls()).toContainEqual([
+      'notify',
+      '--title',
+      'ghwt',
+      '--subtitle',
+      'needs attention',
+      '--workspace',
+      'workspace:7',
+    ]);
+  });
+});
+
+describe('createSession initial-surface reuse (new-workspace returns a surface)', () => {
+  it('reuses the workspace initial surface for window 0, allocates fresh after', async () => {
+    let surfaceN = 0;
+    execaMock.mockImplementation(async (_bin: string, args: string[]) => {
+      const sub = args[0];
+      if (sub === 'list-workspaces') return { stdout: '[]' };
+      // new-workspace surfaces the initial surface ref alongside the workspace.
+      if (sub === 'new-workspace') return { stdout: 'OK workspace:1 surface:1' };
+      if (sub === 'new-surface' || sub === 'new-split') {
+        surfaceN += 1;
+        return { stdout: `OK surface:${100 + surfaceN}` };
+      }
+      return { stdout: '' };
+    });
+
+    const mgr = new CmuxSessionManager();
+    const config: SessionConfig = {
+      name: 's',
+      windows: [
+        { name: 'a', panes: ['echo a'] },
+        { name: 'b', panes: ['echo b'] },
+      ],
+    };
+    await mgr.createSession('p-b', config, '/wt', 'p', 'b');
+
+    const c = cmuxCalls();
+    // Window 0 reuses surface:1 (the initial surface) - no new-surface for it.
+    expect(c).toContainEqual(['send', 'echo a\n', '--surface', 'surface:1']);
+    // Window 1 allocates a fresh surface (first new-surface call).
+    const newSurfaceCalls = c.filter((a) => a[0] === 'new-surface');
+    expect(newSurfaceCalls).toEqual([['new-surface', '--workspace', 'workspace:1', '--json']]);
+    expect(c).toContainEqual(['send', 'echo b\n', '--surface', 'surface:101']);
+  });
+
+  it('parses --json surface_ref form (not just OK text)', async () => {
+    execaMock.mockImplementation(async (_bin: string, args: string[]) => {
+      const sub = args[0];
+      if (sub === 'list-workspaces') return { stdout: '[]' };
+      if (sub === 'new-workspace')
+        return { stdout: JSON.stringify({ workspace_ref: 'workspace:4' }) };
+      if (sub === 'new-surface') return { stdout: JSON.stringify({ surface_ref: 'surface:9' }) };
+      return { stdout: '' };
+    });
+
+    const mgr = new CmuxSessionManager();
+    await mgr.createSession(
+      'p-b',
+      { name: 's', windows: [{ name: 'w', panes: ['ls'] }] },
+      '/wt',
+      'p',
+      'b',
+    );
+
+    const c = cmuxCalls();
+    expect(c).toContainEqual(['rename-workspace', '--workspace', 'workspace:4', 'ghwt:p-b']);
+    expect(c).toContainEqual(['new-surface', '--workspace', 'workspace:4', '--json']);
+    expect(c).toContainEqual(['send', 'ls\n', '--surface', 'surface:9']);
+  });
+});
+
+describe('assertCmuxReady', () => {
+  it('throws a macOS-only message when ping fails', async () => {
+    execaMock.mockImplementation(async (_bin: string, args: string[]) => {
+      if (args[0] === 'ping') throw new Error('ECONNREFUSED');
+      return { stdout: '' };
+    });
+    await expect(assertCmuxReady()).rejects.toThrow(/macOS-only/);
+  });
+
+  it('throws when the version is below the floor', async () => {
+    execaMock.mockImplementation(async (_bin: string, args: string[]) => {
+      if (args[0] === 'ping') return { stdout: 'pong' };
+      if (args[0] === 'version') return { stdout: 'cmux 0.62.9' };
+      return { stdout: '' };
+    });
+    await expect(assertCmuxReady()).rejects.toThrow(/too old/);
+  });
+
+  it('accepts an unparseable version (presence already confirmed by ping)', async () => {
+    execaMock.mockImplementation(async (_bin: string, args: string[]) => {
+      if (args[0] === 'ping') return { stdout: 'pong' };
+      if (args[0] === 'version') return { stdout: 'cmux dev-build' };
+      return { stdout: '' };
+    });
+    await expect(assertCmuxReady()).resolves.toBeUndefined();
+  });
+
+  it('does not hard-block when `cmux version` itself fails', async () => {
+    execaMock.mockImplementation(async (_bin: string, args: string[]) => {
+      if (args[0] === 'ping') return { stdout: 'pong' };
+      if (args[0] === 'version') throw new Error('unknown subcommand');
+      return { stdout: '' };
+    });
+    await expect(assertCmuxReady()).resolves.toBeUndefined();
+  });
+});
+
+describe('parseCmuxVersion', () => {
+  it('parses a plain version', () => {
+    expect(parseCmuxVersion('cmux 0.64.1')).toEqual([0, 64, 1]);
+  });
+  it('strips a commit/build suffix', () => {
+    expect(parseCmuxVersion('0.63.0+abc1234')).toEqual([0, 63, 0]);
+  });
+  it('returns null when unparseable', () => {
+    expect(parseCmuxVersion('unknown')).toBeNull();
+  });
+});

--- a/src/__tests__/lib/terminal-session-herdr.integration.test.ts
+++ b/src/__tests__/lib/terminal-session-herdr.integration.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { execa } from 'execa';
+import { HerdrSessionManager } from '../../lib/terminal-session-herdr.js';
+import type { SessionConfig } from '../../lib/terminal-session-base.js';
+
+/**
+ * Real-herdr integration test (herdr installed + background server running).
+ *
+ * The cmux backend's history (its mocked unit contract did not survive contact
+ * with real cmux) is the reason this exists: it drives the actual `herdr`
+ * binary end to end - create a labelled workspace, verify the pre/pane cascade
+ * really executed via `pane read`, then tear down.
+ *
+ * Self-gating: skipped unless the platform is linux/darwin AND `herdr session
+ * list` reports a running default session. Mirrors how the cmux integration
+ * test stays green when the resource is absent.
+ */
+
+async function herdrReachable(): Promise<boolean> {
+  if (process.platform !== 'darwin' && process.platform !== 'linux') return false;
+  try {
+    const r = await execa('herdr', ['session', 'list', '--json'], { reject: false });
+    if ((r.exitCode ?? 1) !== 0) return false;
+    const parsed = JSON.parse(r.stdout ?? '{}') as {
+      sessions?: Array<{ default?: boolean; running?: boolean }>;
+    };
+    const sessions = Array.isArray(parsed.sessions) ? parsed.sessions : [];
+    const def = sessions.find((s) => s.default) ?? sessions[0];
+    return def?.running === true;
+  } catch {
+    return false;
+  }
+}
+
+describe('herdr integration (real herdr, server running)', () => {
+  const createdIds: string[] = [];
+
+  // Close every workspace any test registered. Idempotent (reject:false), so
+  // a test that already tore its own down needs no fragile bookkeeping - it
+  // just leaves the id here and this double-close is a harmless no-op.
+  afterAll(async () => {
+    for (const id of createdIds) {
+      await execa('herdr', ['workspace', 'close', id], { reject: false }).catch(() => {});
+    }
+  });
+
+  it('createSession builds a ghwt-labelled workspace whose pane runs the cascade', async (ctx) => {
+    if (!(await herdrReachable())) {
+      ctx.skip(); // not linux/darwin / herdr absent / server down
+      return;
+    }
+    const mgr = new HerdrSessionManager(undefined, false);
+    const sessionName = `itest-${Date.now()}`;
+    const config: SessionConfig = {
+      name: 'itest',
+      pre: ['echo GHWT_PRE_OK'],
+      windows: [{ name: 'w', panes: ['echo GHWT_PANE_OK'] }],
+    };
+
+    await mgr.createSession(sessionName, config, process.cwd(), 'proj', 'branch');
+
+    // Resolve the workspace herdr just created (for teardown + pane read).
+    const wsList = await execa('herdr', ['workspace', 'list']);
+    const ws = (
+      JSON.parse(wsList.stdout).result.workspaces as Array<{
+        workspace_id: string;
+        label?: string;
+      }>
+    ).find((w) => w.label === `ghwt:${sessionName}`);
+    expect(ws, 'ghwt-labelled workspace should exist after createSession').toBeTruthy();
+    createdIds.push(ws!.workspace_id);
+
+    expect(await mgr.sessionExists(sessionName)).toBe(true);
+
+    // Find the workspace's pane, let the shell render, assert the cascade ran.
+    const paneList = await execa('herdr', ['pane', 'list', '--workspace', ws!.workspace_id]);
+    const paneId = (JSON.parse(paneList.stdout).result.panes as Array<{ pane_id: string }>)[0]
+      .pane_id;
+
+    await new Promise((r) => setTimeout(r, 2000));
+    const screen = await execa('herdr', ['pane', 'read', paneId, '--source', 'recent']);
+    expect(screen.stdout).toMatch(/GHWT_PRE_OK/);
+    expect(screen.stdout).toMatch(/GHWT_PANE_OK/);
+
+    await mgr.killSession(sessionName);
+    expect(await mgr.sessionExists(sessionName)).toBe(false);
+    // No createdIds bookkeeping: afterAll's close is idempotent (see above).
+  }, 40000);
+});

--- a/src/__tests__/lib/terminal-session-herdr.unit.test.ts
+++ b/src/__tests__/lib/terminal-session-herdr.unit.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// execa is mocked so no real herdr binary is invoked.
+const execaMock = vi.fn();
+vi.mock('execa', () => ({ execa: (...args: unknown[]) => execaMock(...args) }));
+
+import {
+  HerdrSessionManager,
+  parseHerdrVersion,
+  assertHerdrReady,
+} from '../../lib/terminal-session-herdr.js';
+import { SessionConfig } from '../../lib/terminal-session-base.js';
+
+type Call = [string, string[]];
+
+function calls(): Call[] {
+  return execaMock.mock.calls.map((c) => [c[0] as string, c[1] as string[]]);
+}
+
+function herdrCalls(): string[][] {
+  return calls()
+    .filter(([bin]) => bin === 'herdr')
+    .map(([, args]) => args);
+}
+
+/** herdr's envelope shapes, validated against herdr 0.5.10 (server protocol 6). */
+function ok(result: unknown): { stdout: string; exitCode: number } {
+  return { stdout: JSON.stringify({ id: 'cli:x', result }), exitCode: 0 };
+}
+
+let workspaces: Array<{ workspace_id: string; label?: string }> = [];
+
+beforeEach(() => {
+  execaMock.mockReset();
+  workspaces = [];
+
+  let paneN = 1;
+  execaMock.mockImplementation(async (bin: string, args: string[]) => {
+    if (bin !== 'herdr') return { stdout: '', exitCode: 0 };
+    const [a0, a1] = args;
+    if (a0 === '--version') return { stdout: 'herdr 0.5.10', exitCode: 0 };
+    if (a0 === 'session' && a1 === 'list') {
+      return {
+        stdout: JSON.stringify({ sessions: [{ default: true, name: 'default', running: true }] }),
+        exitCode: 0,
+      };
+    }
+    if (a0 === 'workspace' && a1 === 'list') {
+      return ok({ type: 'workspace_list', workspaces });
+    }
+    if (a0 === 'workspace' && a1 === 'create') {
+      return ok({
+        type: 'workspace_created',
+        workspace: { workspace_id: 'w1', label: args[args.indexOf('--label') + 1] },
+        root_pane: { pane_id: 'w1-1' },
+      });
+    }
+    if (a0 === 'pane' && a1 === 'split') {
+      paneN += 1;
+      return ok({ type: 'pane_info', pane: { pane_id: `w1-${paneN}` } });
+    }
+    if (a0 === 'pane' && a1 === 'run') return { stdout: '', exitCode: 0 };
+    if (a0 === 'workspace' && (a1 === 'close' || a1 === 'focus')) {
+      return ok({ type: 'ok' });
+    }
+    return { stdout: '', exitCode: 0 };
+  });
+});
+
+describe('HerdrSessionManager.createSession', () => {
+  it('emits ordered herdr calls: workspace create(label), reuse root pane, run cascade, split', async () => {
+    const mgr = new HerdrSessionManager();
+    const config: SessionConfig = {
+      name: 'sample',
+      pre: ['nvm use'],
+      windows: [{ name: 'editor', panes: ['vim', 'npm test'] }, { name: 'shell' }],
+    };
+
+    await mgr.createSession('proj-branch', config, '/wt', 'proj', 'branch');
+
+    expect(herdrCalls()).toEqual([
+      // sessionExists pre-check
+      ['workspace', 'list'],
+      ['workspace', 'create', '--cwd', '/wt', '--label', 'ghwt:proj-branch', '--no-focus'],
+      // editor pane 0 reuses the root pane (w1-1); cwd == worktree so no cd
+      ['pane', 'run', 'w1-1', 'nvm use'],
+      ['pane', 'run', 'w1-1', 'vim'],
+      // editor pane 1 -> split off the previous pane, cascade re-runs
+      ['pane', 'split', 'w1-1', '--direction', 'right', '--cwd', '/wt', '--no-focus'],
+      ['pane', 'run', 'w1-2', 'nvm use'],
+      ['pane', 'run', 'w1-2', 'npm test'],
+      // window "shell" -> split off the previous pane, cascade, no command
+      ['pane', 'split', 'w1-2', '--direction', 'right', '--cwd', '/wt', '--no-focus'],
+      ['pane', 'run', 'w1-3', 'nvm use'],
+    ]);
+  });
+
+  it('cd the root pane only when the window root differs from the worktree path', async () => {
+    const mgr = new HerdrSessionManager();
+    const config: SessionConfig = {
+      name: 'sample',
+      windows: [{ name: 'srv', root: 'server', panes: ['npm start'] }],
+    };
+
+    await mgr.createSession('p-b', config, '/wt', 'p', 'b');
+
+    const runs = herdrCalls().filter((a) => a[0] === 'pane' && a[1] === 'run');
+    expect(runs).toEqual([
+      ['pane', 'run', 'w1-1', 'cd /wt/server'],
+      ['pane', 'run', 'w1-1', 'npm start'],
+    ]);
+  });
+
+  it('split panes get their cwd via --cwd, not a cd command', async () => {
+    const mgr = new HerdrSessionManager();
+    const config: SessionConfig = {
+      name: 's',
+      windows: [{ name: 'w', root: 'sub', panes: ['a', 'b'] }],
+    };
+
+    await mgr.createSession('p-b', config, '/wt', 'p', 'b');
+
+    const c = herdrCalls();
+    expect(c).toContainEqual([
+      'pane',
+      'split',
+      'w1-1',
+      '--direction',
+      'right',
+      '--cwd',
+      '/wt/sub',
+      '--no-focus',
+    ]);
+    // The split pane's command runs directly - no `cd` for it.
+    expect(c).toContainEqual(['pane', 'run', 'w1-2', 'b']);
+    expect(c).not.toContainEqual(['pane', 'run', 'w1-2', 'cd /wt/sub']);
+  });
+
+  it('skips creation when the workspace already exists', async () => {
+    workspaces = [{ workspace_id: 'w9', label: 'ghwt:p-b' }];
+    const mgr = new HerdrSessionManager();
+
+    await mgr.createSession('p-b', { name: 's', windows: [{ name: 'w' }] }, '/wt', 'p', 'b');
+
+    expect(herdrCalls()).toEqual([['workspace', 'list']]);
+  });
+});
+
+describe('HerdrSessionManager.sessionExists', () => {
+  it('matches by ghwt-stamped label and returns true', async () => {
+    workspaces = [
+      { workspace_id: 'w2', label: 'ghwt:proj-branch' },
+      { workspace_id: 'w3', label: 'something-else' },
+    ];
+    const mgr = new HerdrSessionManager();
+    expect(await mgr.sessionExists('proj-branch')).toBe(true);
+  });
+
+  it('returns false when no label matches', async () => {
+    workspaces = [{ workspace_id: 'w2', label: 'ghwt:other' }];
+    const mgr = new HerdrSessionManager();
+    expect(await mgr.sessionExists('proj-branch')).toBe(false);
+  });
+
+  it('throws on ambiguous multi-label match (never guesses)', async () => {
+    workspaces = [
+      { workspace_id: 'w2', label: 'ghwt:proj-branch' },
+      { workspace_id: 'w5', label: 'ghwt:proj-branch' },
+    ];
+    const mgr = new HerdrSessionManager();
+    await expect(mgr.sessionExists('proj-branch')).rejects.toThrow(/Ambiguous herdr workspace/);
+  });
+});
+
+describe('HerdrSessionManager.killSession', () => {
+  it('resolves the id then closes the workspace', async () => {
+    workspaces = [{ workspace_id: 'w7', label: 'ghwt:p-b' }];
+    const mgr = new HerdrSessionManager();
+
+    await mgr.killSession('p-b');
+
+    expect(herdrCalls()).toContainEqual(['workspace', 'close', 'w7']);
+  });
+
+  it('is a no-op when the workspace is absent', async () => {
+    const mgr = new HerdrSessionManager();
+    await mgr.killSession('p-b');
+    expect(herdrCalls()).toEqual([['workspace', 'list']]);
+  });
+
+  it('does not omit a notify method (herdr has no external notify trigger)', () => {
+    const mgr = new HerdrSessionManager();
+    expect((mgr as unknown as { notify?: unknown }).notify).toBeUndefined();
+  });
+});
+
+describe('HerdrSessionManager.agentStatuses', () => {
+  function mockAgents(
+    wss: Array<{ workspace_id: string; label?: string }>,
+    agents: Array<{ agent_status: string; workspace_id: string }>,
+  ) {
+    execaMock.mockImplementation(async (bin: string, args: string[]) => {
+      if (bin !== 'herdr') return { stdout: '', exitCode: 0 };
+      if (args[0] === 'workspace' && args[1] === 'list') {
+        return ok({ type: 'workspace_list', workspaces: wss });
+      }
+      if (args[0] === 'agent' && args[1] === 'list') {
+        return ok({ type: 'agent_list', agents });
+      }
+      return { stdout: '', exitCode: 0 };
+    });
+  }
+
+  async function statuses() {
+    const map = await new HerdrSessionManager().agentStatuses();
+    expect(map, 'success should return a Map, not null').not.toBeNull();
+    return map!;
+  }
+
+  it('joins agent.workspace_id -> ghwt label -> session name', async () => {
+    mockAgents(
+      [{ workspace_id: 'wA', label: 'ghwt:proj-branch' }],
+      [{ agent_status: 'blocked', workspace_id: 'wA' }],
+    );
+    const map = await statuses();
+    expect(map.get('proj-branch')).toBe('blocked');
+    expect(map.size).toBe(1);
+  });
+
+  it('rolls up to the most-urgent status when a session has multiple agents', async () => {
+    mockAgents(
+      [{ workspace_id: 'wA', label: 'ghwt:p-b' }],
+      [
+        { agent_status: 'working', workspace_id: 'wA' },
+        { agent_status: 'blocked', workspace_id: 'wA' },
+        { agent_status: 'idle', workspace_id: 'wA' },
+      ],
+    );
+    expect((await statuses()).get('p-b')).toBe('blocked');
+  });
+
+  it('ignores agents in non-ghwt (unprefixed/user-created) workspaces', async () => {
+    mockAgents(
+      [
+        { workspace_id: 'wA', label: 'ghwt:mine' },
+        { workspace_id: 'wB', label: 'cmux_integration' },
+      ],
+      [
+        { agent_status: 'working', workspace_id: 'wA' },
+        { agent_status: 'blocked', workspace_id: 'wB' },
+      ],
+    );
+    const map = await statuses();
+    expect(map.get('mine')).toBe('working');
+    expect(map.has('cmux_integration')).toBe(false);
+    expect(map.size).toBe(1);
+  });
+
+  it('normalizes unrecognized statuses to "unknown"', async () => {
+    mockAgents(
+      [{ workspace_id: 'wA', label: 'ghwt:p-b' }],
+      [{ agent_status: 'starting', workspace_id: 'wA' }],
+    );
+    expect((await statuses()).get('p-b')).toBe('unknown');
+  });
+
+  it('keeps the documented `done` state (herdr emits it despite enum docs)', async () => {
+    mockAgents(
+      [{ workspace_id: 'wA', label: 'ghwt:p-b' }],
+      [{ agent_status: 'done', workspace_id: 'wA' }],
+    );
+    expect((await statuses()).get('p-b')).toBe('done');
+  });
+
+  it('success with no live agents returns an empty Map (NOT null) so sync clears stale state', async () => {
+    mockAgents([{ workspace_id: 'wA', label: 'ghwt:p-b' }], []);
+    const map = await statuses();
+    expect(map.size).toBe(0);
+  });
+
+  it('returns null on herdr failure so sync leaves agent_status untouched (no mass-wipe)', async () => {
+    execaMock.mockImplementation(async (bin: string, args: string[]) => {
+      if (bin !== 'herdr') return { stdout: '', exitCode: 0 };
+      if (args[0] === 'agent' && args[1] === 'list') {
+        return {
+          stdout: JSON.stringify({ error: { code: 'server_error', message: 'boom' } }),
+          exitCode: 1,
+        };
+      }
+      return { stdout: '', exitCode: 0 };
+    });
+    expect(await new HerdrSessionManager().agentStatuses()).toBeNull();
+  });
+});
+
+describe('hardened herdr exec (reliable exit codes + structured errors)', () => {
+  it('createSession throws on a herdr {"error":...} envelope (no silent misroute)', async () => {
+    execaMock.mockImplementation(async (bin: string, args: string[]) => {
+      if (bin !== 'herdr') return { stdout: '', exitCode: 0 };
+      if (args[0] === 'workspace' && args[1] === 'list') {
+        return { stdout: JSON.stringify({ result: { workspaces: [] } }), exitCode: 0 };
+      }
+      if (args[0] === 'workspace' && args[1] === 'create') {
+        return {
+          stdout: JSON.stringify({ error: { code: 'invalid_params', message: 'bad cwd' } }),
+          exitCode: 1,
+        };
+      }
+      return { stdout: '', exitCode: 0 };
+    });
+    const mgr = new HerdrSessionManager();
+    await expect(
+      mgr.createSession(
+        'p-b',
+        { name: 's', windows: [{ name: 'w', panes: ['ls'] }] },
+        '/wt',
+        'p',
+        'b',
+      ),
+    ).rejects.toThrow(/invalid_params: bad cwd/);
+    expect(herdrCalls().some((a) => a[0] === 'pane' && a[1] === 'run')).toBe(false);
+  });
+
+  it('createSession throws on a non-zero exit even without an error envelope', async () => {
+    execaMock.mockImplementation(async (bin: string, args: string[]) => {
+      if (bin !== 'herdr') return { stdout: '', exitCode: 0 };
+      if (args[0] === 'workspace' && args[1] === 'list') {
+        return { stdout: JSON.stringify({ result: { workspaces: [] } }), exitCode: 0 };
+      }
+      if (args[0] === 'workspace' && args[1] === 'create') {
+        return { stdout: '', exitCode: 2 };
+      }
+      return { stdout: '', exitCode: 0 };
+    });
+    const mgr = new HerdrSessionManager();
+    await expect(
+      mgr.createSession('p-b', { name: 's', windows: [{ name: 'w' }] }, '/wt', 'p', 'b'),
+    ).rejects.toThrow(/herdr workspace failed/);
+  });
+});
+
+describe('assertHerdrReady', () => {
+  it('throws an install message when herdr is not installed', async () => {
+    execaMock.mockImplementation(async (_bin: string, args: string[]) => {
+      if (args[0] === '--version') throw new Error('spawn herdr ENOENT');
+      return { stdout: '', exitCode: 0 };
+    });
+    await expect(assertHerdrReady()).rejects.toThrow(/install\.sh/);
+  });
+
+  it('throws an actionable message when the server is not running', async () => {
+    execaMock.mockImplementation(async (_bin: string, args: string[]) => {
+      if (args[0] === '--version') return { stdout: 'herdr 0.5.10', exitCode: 0 };
+      if (args[0] === 'session' && args[1] === 'list') {
+        return {
+          stdout: JSON.stringify({ sessions: [{ default: true, running: false }] }),
+          exitCode: 0,
+        };
+      }
+      return { stdout: '', exitCode: 0 };
+    });
+    await expect(assertHerdrReady()).rejects.toThrow(/server is not running/);
+  });
+
+  it('throws when the version is below the floor', async () => {
+    execaMock.mockImplementation(async (_bin: string, args: string[]) => {
+      if (args[0] === '--version') return { stdout: 'herdr 0.4.0', exitCode: 0 };
+      if (args[0] === 'session' && args[1] === 'list') {
+        return {
+          stdout: JSON.stringify({ sessions: [{ default: true, running: true }] }),
+          exitCode: 0,
+        };
+      }
+      return { stdout: '', exitCode: 0 };
+    });
+    await expect(assertHerdrReady()).rejects.toThrow(/too old/);
+  });
+
+  it('accepts an unparseable version once the server is proven up', async () => {
+    execaMock.mockImplementation(async (_bin: string, args: string[]) => {
+      if (args[0] === '--version') return { stdout: 'herdr dev-build', exitCode: 0 };
+      if (args[0] === 'session' && args[1] === 'list') {
+        return {
+          stdout: JSON.stringify({ sessions: [{ default: true, running: true }] }),
+          exitCode: 0,
+        };
+      }
+      return { stdout: '', exitCode: 0 };
+    });
+    await expect(assertHerdrReady()).resolves.toBeUndefined();
+  });
+});
+
+describe('parseHerdrVersion', () => {
+  it('parses a plain version', () => {
+    expect(parseHerdrVersion('herdr 0.5.10')).toEqual([0, 5, 10]);
+  });
+  it('returns null when unparseable', () => {
+    expect(parseHerdrVersion('dev-build')).toBeNull();
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import { ciDownloadCommand } from './commands/ci-artifacts-download.js';
 import { pathCiArtifactsCommand } from './commands/path-ci-artifacts.js';
 import { pathNoteCommand } from './commands/path-note.js';
 import { updateAgentCommandsCommand } from './commands/update-agent-commands.js';
+import { installSyncHookCommand } from './commands/install-sync-hook.js';
 
 const program = new Command();
 
@@ -396,6 +397,19 @@ program
   .action(async (options) => {
     try {
       await updateAgentCommandsCommand(options);
+    } catch (error) {
+      console.error('Error:', error);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('install-sync-hook')
+  .description('Install a Claude Code Stop hook running "ghwt sync --this" (cmux bridge)')
+  .option('--uninstall', 'Remove the hook instead of installing it')
+  .action(async (options) => {
+    try {
+      await installSyncHookCommand(options);
     } catch (error) {
       console.error('Error:', error);
       process.exit(1);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -135,9 +135,9 @@ SORT created DESC
 ## Needs Attention
 
 \`\`\`dataview
-TABLE project, branch, pr_checks, commits_ahead, days_since_activity
+TABLE project, branch, pr_checks, agent_status, commits_ahead, days_since_activity
 FROM "projects"
-WHERE (pr_checks = "failing" OR days_since_activity > 7 OR has_uncommitted_changes = true)
+WHERE (pr_checks = "failing" OR days_since_activity > 7 OR has_uncommitted_changes = true OR agent_status = "blocked")
 SORT days_since_activity DESC
 \`\`\`
 

--- a/src/commands/install-sync-hook.ts
+++ b/src/commands/install-sync-hook.ts
@@ -1,0 +1,17 @@
+import { installSyncHook, uninstallSyncHook, SYNC_HOOK_COMMAND } from '../lib/sync-hook.js';
+
+export async function installSyncHookCommand(options?: { uninstall?: boolean }): Promise<void> {
+  if (options?.uninstall) {
+    const { settingsPath } = uninstallSyncHook();
+    console.log(`🧹 Removed ghwt sync Stop hook from ${settingsPath}`);
+    return;
+  }
+
+  const { settingsPath, created } = installSyncHook();
+  console.log(
+    `✅ Installed ghwt sync Stop hook ${created ? '(created' : '(updated'} ${settingsPath})`,
+  );
+  console.log(`   On every Claude turn end: ${SYNC_HOOK_COMMAND}`);
+  console.log(`   With terminalMultiplexer: 'cmux', this rings the worktree's`);
+  console.log(`   workspace on a transition into needs-attention.`);
+}

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -23,10 +23,44 @@ import {
   getSessionManager,
 } from '../lib/terminal-session.js';
 import { getNotePath, getSessionName, parseBranchFromOldFormat } from '../lib/paths.js';
-import { WorktreeMetadata, NoteFrontmatter } from '../types.js';
+import { WorktreeMetadata, NoteFrontmatter, AgentStatus } from '../types.js';
 import { pickWorktree } from '../lib/worktree-picker.js';
 import { needsAttention } from '../lib/attention.js';
 import { TerminalSessionManager } from '../lib/terminal-session-base.js';
+
+/**
+ * Best-effort fetch of live agent state keyed by ghwt session name. Returns
+ * `null` when there is no authoritative snapshot (backend not agent-aware, or
+ * the fetch failed) - the caller must then leave agent_status untouched. A
+ * non-null map (even empty) is authoritative: a session absent from it has no
+ * live agent and its stale agent_status must be cleared. Never throws (same
+ * advisory contract as the notify bridge).
+ */
+async function fetchAgentStatuses(
+  manager: TerminalSessionManager,
+): Promise<Map<string, AgentStatus> | null> {
+  if (!manager.agentStatuses) return null;
+  try {
+    return await manager.agentStatuses();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Apply an authoritative agent-state snapshot to a worktree's updates.
+ * Absent-from-map => the agent is gone; write 'unknown' so a one-time
+ * 'blocked' does not stick in the note forever (the spread merge in
+ * updateNoteMetadata would otherwise preserve the old value).
+ */
+function applyAgentStatus(
+  updates: Partial<WorktreeMetadata>,
+  snapshot: Map<string, AgentStatus> | null,
+  sessionName: string,
+): void {
+  if (!snapshot) return;
+  updates.agent_status = snapshot.get(sessionName) ?? 'unknown';
+}
 
 /**
  * Ring the worktree's session only on a *transition* into needs-attention
@@ -239,12 +273,16 @@ async function syncSingleWorktree(
     }
   }
 
-  updateNoteMetadata(notePath, updates);
-
-  // Check/recreate session
   const sessionName = getSessionName(project, branch);
   const manager = getSessionManager(config);
 
+  // Live agent state (herdr only; null otherwise). Set before the metadata
+  // write so the dashboard reflects it and needsAttention() sees it.
+  applyAgentStatus(updates, await fetchAgentStatuses(manager), sessionName);
+
+  updateNoteMetadata(notePath, updates);
+
+  // Check/recreate session
   const sessionExists = await manager.sessionExists(sessionName);
   if (!sessionExists) {
     const configPath = findSessionConfig(project, config);
@@ -324,6 +362,11 @@ export async function syncCommand(
 
   let syncedCount = 0;
   let errorCount = 0;
+
+  // Live agent state, fetched once for the whole bulk sync (herdr does two
+  // CLI calls per fetch - doing it per-note would be wasteful). No-op map for
+  // non-agent-aware backends.
+  const agentStatusBySession = await fetchAgentStatuses(getSessionManager(config));
 
   // Scan projects
   const projectDirs = selectedProject
@@ -478,12 +521,17 @@ export async function syncCommand(
           }
         }
 
+        // Live agent state (herdr only) before the metadata write so the
+        // dashboard reflects it and the attention transition sees it.
+        const sessionName = getSessionName(proj, branch);
+        applyAgentStatus(updates, agentStatusBySession, sessionName);
+
         // Update note
         updateNoteMetadata(notePath, updates);
 
         await notifyOnAttentionTransition(
           getSessionManager(config),
-          getSessionName(proj, branch),
+          sessionName,
           proj,
           branch,
           frontmatter,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -17,12 +17,40 @@ import {
   getCIArtifactsPath,
 } from '../lib/ci-artifacts.js';
 import { listWorktrees, getCurrentWorktreeContext } from '../lib/worktree-list.js';
-import { findSessionConfig, loadSessionConfig } from '../lib/terminal-session.js';
-import { TmuxSessionManager } from '../lib/terminal-session-tmux.js';
-import { ZellijSessionManager } from '../lib/terminal-session-zellij.js';
+import {
+  findSessionConfig,
+  loadSessionConfig,
+  getSessionManager,
+} from '../lib/terminal-session.js';
 import { getNotePath, getSessionName, parseBranchFromOldFormat } from '../lib/paths.js';
-import { WorktreeMetadata } from '../types.js';
+import { WorktreeMetadata, NoteFrontmatter } from '../types.js';
 import { pickWorktree } from '../lib/worktree-picker.js';
+import { needsAttention } from '../lib/attention.js';
+import { TerminalSessionManager } from '../lib/terminal-session-base.js';
+
+/**
+ * Ring the worktree's session only on a *transition* into needs-attention
+ * (avoids every-sync notification spam). No-op for tmux/zellij (no notify).
+ */
+export async function notifyOnAttentionTransition(
+  manager: TerminalSessionManager,
+  sessionName: string,
+  project: string,
+  branch: string,
+  prior: NoteFrontmatter,
+  updates: Partial<WorktreeMetadata>,
+): Promise<void> {
+  if (!manager.notify) return;
+  try {
+    const was = needsAttention(prior);
+    const now = needsAttention({ ...prior, ...(updates as NoteFrontmatter) });
+    if (!was && now) {
+      await manager.notify(sessionName, 'ghwt: needs attention', `${project}/${branch}`);
+    }
+  } catch {
+    // Notification is advisory only - never fail a sync over it.
+  }
+}
 
 interface SyncOptions {
   verbose?: boolean;
@@ -215,8 +243,7 @@ async function syncSingleWorktree(
 
   // Check/recreate session
   const sessionName = getSessionName(project, branch);
-  const manager =
-    config.terminalMultiplexer === 'zellij' ? new ZellijSessionManager() : new TmuxSessionManager();
+  const manager = getSessionManager(config);
 
   const sessionExists = await manager.sessionExists(sessionName);
   if (!sessionExists) {
@@ -240,6 +267,8 @@ async function syncSingleWorktree(
       }
     }
   }
+
+  await notifyOnAttentionTransition(manager, sessionName, project, branch, frontmatter, updates);
 
   console.log(
     `✅ Synced: ${project}/${branch} (ahead: ${gitInfo.commitsAhead}, behind: ${gitInfo.commitsBehind})`,
@@ -452,6 +481,15 @@ export async function syncCommand(
         // Update note
         updateNoteMetadata(notePath, updates);
 
+        await notifyOnAttentionTransition(
+          getSessionManager(config),
+          getSessionName(proj, branch),
+          proj,
+          branch,
+          frontmatter,
+          updates,
+        );
+
         if (options?.verbose) {
           console.log(
             `✅ Synced: ${proj}/${branch} (ahead: ${gitInfo.commitsAhead}, behind: ${gitInfo.commitsBehind})`,
@@ -513,10 +551,7 @@ export async function syncCommand(
     }
 
     // If worktree exists but session doesn't, recreate it
-    const manager =
-      config.terminalMultiplexer === 'zellij'
-        ? new ZellijSessionManager()
-        : new TmuxSessionManager();
+    const manager = getSessionManager(config);
 
     const sessionExists = await manager.sessionExists(sessionName);
     if (!sessionExists) {

--- a/src/lib/attention.ts
+++ b/src/lib/attention.ts
@@ -12,8 +12,14 @@ export const ATTENTION_STALE_DAYS = 7;
  *
  * This is the shared TS predicate behind the dashboard's "Needs Attention"
  * Dataview query (init.ts):
- *   pr_checks = "failing" OR days_since_activity > 7 OR has_uncommitted_changes = true
+ *   pr_checks = "failing" OR days_since_activity > 7
+ *     OR has_uncommitted_changes = true OR agent_status = "blocked"
  * plus failing CI (the ci_checks field), which the issue calls out explicitly.
+ * Keep this predicate and that Dataview query in sync if either changes.
+ *
+ * agent_status === 'blocked' (agent-aware backends only, e.g. herdr: the
+ * coding agent is waiting on the human) is exactly the per-worktree signal
+ * this dashboard exists to surface, so it counts as needs-attention.
  *
  * Defensive about field presence: frontmatter is an open record.
  */
@@ -22,10 +28,12 @@ export function needsAttention(frontmatter: NoteFrontmatter): boolean {
   const ciChecks = frontmatter.ci_checks;
   const daysSinceActivity = frontmatter.days_since_activity;
   const hasUncommitted = frontmatter.has_uncommitted_changes;
+  const agentStatus = frontmatter.agent_status;
 
   if (prChecks === 'failing') return true;
   if (ciChecks === 'failing') return true;
   if (hasUncommitted === true) return true;
+  if (agentStatus === 'blocked') return true;
   if (typeof daysSinceActivity === 'number' && daysSinceActivity > ATTENTION_STALE_DAYS) {
     return true;
   }

--- a/src/lib/attention.ts
+++ b/src/lib/attention.ts
@@ -1,0 +1,33 @@
+import { NoteFrontmatter } from '../types.js';
+
+/**
+ * Staleness threshold (days since activity) for "needs attention".
+ * Mirrors the dashboard's Dataview "Needs Attention" query in init.ts -
+ * keep the two in sync if either changes.
+ */
+export const ATTENTION_STALE_DAYS = 7;
+
+/**
+ * Whether a worktree currently needs attention.
+ *
+ * This is the shared TS predicate behind the dashboard's "Needs Attention"
+ * Dataview query (init.ts):
+ *   pr_checks = "failing" OR days_since_activity > 7 OR has_uncommitted_changes = true
+ * plus failing CI (the ci_checks field), which the issue calls out explicitly.
+ *
+ * Defensive about field presence: frontmatter is an open record.
+ */
+export function needsAttention(frontmatter: NoteFrontmatter): boolean {
+  const prChecks = frontmatter.pr_checks;
+  const ciChecks = frontmatter.ci_checks;
+  const daysSinceActivity = frontmatter.days_since_activity;
+  const hasUncommitted = frontmatter.has_uncommitted_changes;
+
+  if (prChecks === 'failing') return true;
+  if (ciChecks === 'failing') return true;
+  if (hasUncommitted === true) return true;
+  if (typeof daysSinceActivity === 'number' && daysSinceActivity > ATTENTION_STALE_DAYS) {
+    return true;
+  }
+  return false;
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -26,7 +26,7 @@ export const GhwtConfigSchema = z
       .default(null)
       .describe('Sync interval in seconds (minimum 60, null for no auto-sync)'),
     terminalMultiplexer: z
-      .enum(['tmux', 'zellij', 'cmux'])
+      .enum(['tmux', 'zellij', 'cmux', 'herdr'])
       .default('tmux')
       .describe('Terminal multiplexer to use for sessions (cmux is macOS-only)'),
     terminalUI: z

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -26,9 +26,9 @@ export const GhwtConfigSchema = z
       .default(null)
       .describe('Sync interval in seconds (minimum 60, null for no auto-sync)'),
     terminalMultiplexer: z
-      .enum(['tmux', 'zellij'])
+      .enum(['tmux', 'zellij', 'cmux'])
       .default('tmux')
-      .describe('Terminal multiplexer to use for sessions'),
+      .describe('Terminal multiplexer to use for sessions (cmux is macOS-only)'),
     terminalUI: z
       .enum(['wezterm', 'ghostty', 'none'])
       .default('wezterm')

--- a/src/lib/sync-hook.ts
+++ b/src/lib/sync-hook.ts
@@ -1,0 +1,116 @@
+import { homedir } from 'os';
+import { join, dirname } from 'path';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+
+/**
+ * Claude Code Stop-hook installer for the cmux integration (A3).
+ *
+ * cmux has no hook registry of its own - its integration docs describe hooks
+ * as agent-side scripts the coding agent invokes. So the "agent task-completion
+ * -> ghwt sync --this" bridge is wired on the Claude Code side: a Stop hook
+ * that runs `ghwt sync --this`, which (via the sync notify bridge) rings the
+ * worktree's cmux workspace on a transition into needs-attention.
+ *
+ * Idempotent remove-then-write, modeled on setupAgentCommands().
+ *
+ * `|| true` keeps the hook non-fatal: sync --this calls process.exit(1) on
+ * error, and a Stop hook fires on every turn - a failed sync must never block
+ * the agent (the only softening the issue's Phase 3.4 caveat justifies).
+ */
+export const SYNC_HOOK_COMMAND = 'ghwt sync --this || true';
+
+interface CommandHook {
+  type: 'command';
+  command: string;
+}
+
+interface HookGroup {
+  matcher?: string;
+  hooks: CommandHook[];
+}
+
+interface ClaudeSettings {
+  hooks?: { Stop?: HookGroup[]; [key: string]: HookGroup[] | undefined };
+  [key: string]: unknown;
+}
+
+export function getClaudeSettingsPath(): string {
+  return join(homedir(), '.claude', 'settings.json');
+}
+
+function readSettings(settingsPath: string): ClaudeSettings {
+  if (!existsSync(settingsPath)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    return parsed && typeof parsed === 'object' ? (parsed as ClaudeSettings) : {};
+  } catch (error) {
+    throw new Error(
+      `Could not parse ${settingsPath} (invalid JSON): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+/** Drop any Stop group that contains our sync hook (idempotency). */
+function stripSyncHook(groups: HookGroup[]): HookGroup[] {
+  return groups
+    .map((g) => ({
+      ...g,
+      hooks: (g.hooks || []).filter((h) => h.command !== SYNC_HOOK_COMMAND),
+    }))
+    .filter((g) => g.hooks.length > 0);
+}
+
+export interface InstallResult {
+  settingsPath: string;
+  created: boolean;
+}
+
+/**
+ * Idempotently install the ghwt sync Stop hook into the user's Claude
+ * settings. Preserves all other settings and unrelated Stop hooks.
+ */
+export function installSyncHook(): InstallResult {
+  const settingsPath = getClaudeSettingsPath();
+  const created = !existsSync(settingsPath);
+
+  const settings = readSettings(settingsPath);
+  const hooks = settings.hooks || {};
+  const existingStop = Array.isArray(hooks.Stop) ? hooks.Stop : [];
+
+  const nextStop: HookGroup[] = [
+    ...stripSyncHook(existingStop),
+    { hooks: [{ type: 'command', command: SYNC_HOOK_COMMAND }] },
+  ];
+
+  const next: ClaudeSettings = {
+    ...settings,
+    hooks: { ...hooks, Stop: nextStop },
+  };
+
+  mkdirSync(dirname(settingsPath), { recursive: true });
+  writeFileSync(settingsPath, JSON.stringify(next, null, 2) + '\n');
+
+  return { settingsPath, created };
+}
+
+/** Remove the ghwt sync Stop hook (idempotent). */
+export function uninstallSyncHook(): InstallResult {
+  const settingsPath = getClaudeSettingsPath();
+  if (!existsSync(settingsPath)) return { settingsPath, created: false };
+
+  const settings = readSettings(settingsPath);
+  const hooks = settings.hooks || {};
+  const existingStop = Array.isArray(hooks.Stop) ? hooks.Stop : [];
+  const nextStop = stripSyncHook(existingStop);
+
+  const { Stop: _dropped, ...otherHooks } = hooks;
+  void _dropped;
+  const nextHooks = nextStop.length === 0 ? otherHooks : { ...otherHooks, Stop: nextStop };
+
+  const next: ClaudeSettings = { ...settings, hooks: nextHooks };
+  writeFileSync(settingsPath, JSON.stringify(next, null, 2) + '\n');
+
+  return { settingsPath, created: false };
+}

--- a/src/lib/terminal-session-base.ts
+++ b/src/lib/terminal-session-base.ts
@@ -1,4 +1,9 @@
 import { createHash } from 'crypto';
+import type { AgentStatus } from '../types.js';
+
+// Re-exported so session backends can import it from this module alongside
+// the manager interface (canonical definition lives in types.ts).
+export type { AgentStatus };
 
 export interface WindowConfig {
   name: string;
@@ -85,6 +90,23 @@ export interface TerminalSessionManager {
    * (only cmux; ignored by tmux/zellij - they omit this method)
    */
   notify?(sessionName: string, title: string, subtitle?: string): Promise<void>;
+
+  /**
+   * Map ghwt session name -> most-urgent live agent status for that session.
+   * (only herdr; omitted by tmux/zellij/cmux exactly like notify).
+   *
+   * Return-value contract (matters for clearing stale state in sync):
+   *   - `Map` (possibly empty) = authoritative current snapshot. A session
+   *     absent from the map has no live agent right now; the caller MUST treat
+   *     that as "clear", not "no data" (else a one-time `blocked` sticks in
+   *     the note forever after the agent exits).
+   *   - `null` = could not determine (backend unreachable / CLI failure).
+   *     The caller must leave the existing agent_status untouched so a
+   *     transient herdr outage doesn't wipe every session's state.
+   * Never throws (a transient failure resolves to `null`), so sync never
+   * fails over this advisory signal.
+   */
+  agentStatuses?(): Promise<Map<string, AgentStatus> | null>;
 }
 
 export interface TemplateVars {
@@ -143,6 +165,21 @@ export async function isCmuxAvailable(): Promise<boolean> {
   try {
     const { execa } = await import('execa');
     await execa('cmux', ['--help']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if the herdr CLI is present (presence-only, never throws).
+ * Mirrors isCmuxAvailable: swallow errors, return boolean. Server-liveness
+ * and version-floor enforcement live in terminal-session-herdr.ts.
+ */
+export async function isHerdrAvailable(): Promise<boolean> {
+  try {
+    const { execa } = await import('execa');
+    await execa('herdr', ['--version']);
     return true;
   } catch {
     return false;

--- a/src/lib/terminal-session-base.ts
+++ b/src/lib/terminal-session-base.ts
@@ -79,6 +79,12 @@ export interface TerminalSessionManager {
    * Kill session
    */
   killSession(sessionName: string): Promise<void>;
+
+  /**
+   * Ring the session's surface with a desktop notification.
+   * (only cmux; ignored by tmux/zellij - they omit this method)
+   */
+  notify?(sessionName: string, title: string, subtitle?: string): Promise<void>;
 }
 
 export interface TemplateVars {
@@ -122,6 +128,21 @@ export async function isUIAvailable(ui: 'wezterm' | 'ghostty' | 'none'): Promise
   try {
     const { execa } = await import('execa');
     await execa(ui, ['--help']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if the cmux CLI is present (presence-only, never throws).
+ * Mirrors isUIAvailable: swallow errors, return boolean. Version-floor and
+ * socket-liveness enforcement live in terminal-session-cmux.ts.
+ */
+export async function isCmuxAvailable(): Promise<boolean> {
+  try {
+    const { execa } = await import('execa');
+    await execa('cmux', ['--help']);
     return true;
   } catch {
     return false;

--- a/src/lib/terminal-session-cmux.ts
+++ b/src/lib/terminal-session-cmux.ts
@@ -1,0 +1,425 @@
+import { execa } from 'execa';
+import { join } from 'path';
+import { GhwtConfig } from '../types.js';
+import {
+  TerminalSessionManager,
+  SessionConfig,
+  TemplateVars,
+  AttachOptions,
+  substituteVariables,
+  normalizeSessionConfig,
+} from './terminal-session-base.js';
+
+/**
+ * cmux session backend (macOS-only, opt-in via terminalMultiplexer: 'cmux').
+ *
+ * Arms-length integration: this adapter shells out to the `cmux` binary only.
+ * No linking, no libghostty, no socket parsing beyond the documented CLI.
+ * All cmux-specific behavior is quarantined to this file so the rest of ghwt
+ * stays portable and MIT-clean.
+ *
+ * Identity model: cmux assigns its own workspace ids; it has no deterministic
+ * name addressing. ghwt stamps a title (`ghwt:<sessionName>`) via
+ * `cmux rename-workspace` right after creation and resolves the workspace
+ * fresh on every call by matching that title in `list-workspaces --json`.
+ * Nothing is persisted (cmux workspaces are ephemeral + enumerable).
+ *
+ * cmux is UI+multiplexer fused: `terminalUI` is a no-op for this backend
+ * (cmux *is* the UI), exactly as tmux/zellij ignore cmux-only session fields.
+ */
+
+/** Minimum supported cmux version (gives stable ref-addressing + rename-workspace). */
+export const CMUX_MIN_VERSION = '0.63.0';
+
+/** Title namespace so ghwt-managed workspaces don't collide with user-created ones. */
+const TITLE_PREFIX = 'ghwt:';
+
+/**
+ * Shell-not-ready race after surface creation (cmux issue #2538): there is no
+ * --command flag on new-surface/new-split, so a `send` immediately after
+ * creation can land before the shell is interactive. Short fixed wait,
+ * overridable via GHWT_CMUX_SURFACE_DELAY_MS (also lets tests set it to 0).
+ * Read at call time so the env override doesn't depend on import order.
+ */
+function surfaceReadyDelayMs(): number {
+  const raw = process.env.GHWT_CMUX_SURFACE_DELAY_MS;
+  const parsed = raw === undefined ? NaN : Number(raw);
+  if (!Number.isFinite(parsed)) return 600;
+  // Clamp: reject negatives and absurd waits from a fat-fingered override.
+  return Math.min(Math.max(parsed, 0), 60_000);
+}
+
+interface CmuxWorkspace {
+  ref: string;
+  id?: string;
+  index?: number;
+  title?: string;
+  selected?: boolean;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * cmux ref-creating commands print `OK workspace:N` / `OK surface:N` and,
+ * with --json, a small object. Field names for the JSON form are not
+ * documented and the tool churns fast, so parse defensively: try JSON with
+ * several candidate keys, then fall back to the documented text form.
+ */
+function parseRef(stdout: string, kind: 'workspace' | 'surface'): string | null {
+  const trimmed = stdout.trim();
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    const candidates =
+      kind === 'workspace'
+        ? ['workspace_ref', 'workspaceRef', 'workspace', 'ref']
+        : ['surface_ref', 'surfaceRef', 'surface', 'ref'];
+    for (const key of candidates) {
+      const value = parsed?.[key];
+      if (typeof value === 'string' && value.length > 0) {
+        return value;
+      }
+    }
+  } catch {
+    // Not JSON - fall through to text parsing.
+  }
+
+  const match = trimmed.match(new RegExp(`\\b${kind}:\\d+\\b`));
+  return match ? match[0] : null;
+}
+
+/**
+ * Parse `cmux version` output into a comparable [major, minor, patch] tuple.
+ * Strips any commit/build suffix (cmux v0.61.0+ appends commit metadata).
+ * ghwt has no other version-parsing precedent - this is a deliberate new
+ * pattern, scoped to enforcing the cmux floor.
+ */
+export function parseCmuxVersion(versionOutput: string): [number, number, number] | null {
+  const match = versionOutput.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareVersions(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+/**
+ * Probe cmux: socket alive (`ping`) + version floor (`version`).
+ * Throws with an actionable, macOS-only message on any failure.
+ * Mirrors the isUIAvailable not-found block in terminal-session.ts.
+ */
+export async function assertCmuxReady(): Promise<void> {
+  try {
+    await execa('cmux', ['ping']);
+  } catch {
+    throw new Error(
+      `cmux is not reachable (terminalMultiplexer: 'cmux').\n` +
+        `   cmux is macOS-only. Install/start it: https://cmux.com (then open the app).`,
+    );
+  }
+
+  let versionStdout: string;
+  try {
+    ({ stdout: versionStdout } = await execa('cmux', ['version']));
+  } catch {
+    // `cmux version` itself failed - presence already confirmed by ping, so
+    // don't hard-block (older cmux may lack the subcommand).
+    return;
+  }
+
+  // Comparison + throw live outside the try so a too-old failure can never be
+  // swallowed by the subprocess catch (no message-string sniffing).
+  const got = parseCmuxVersion(versionStdout);
+  const min = parseCmuxVersion(CMUX_MIN_VERSION);
+  if (got && min && compareVersions(got, min) < 0) {
+    throw new Error(
+      `cmux ${got.join('.')} is too old; ghwt needs >= ${CMUX_MIN_VERSION}. Upgrade cmux.`,
+    );
+  }
+  // Unparseable version string: presence confirmed by ping, accept it.
+}
+
+export class CmuxSessionManager implements TerminalSessionManager {
+  constructor(
+    private config?: GhwtConfig,
+    private verbose = false,
+  ) {}
+
+  private workspaceTitle(sessionName: string): string {
+    return `${TITLE_PREFIX}${sessionName}`;
+  }
+
+  private async listWorkspaces(): Promise<CmuxWorkspace[]> {
+    try {
+      const { stdout } = await execa('cmux', ['list-workspaces', '--json']);
+      const parsed = JSON.parse(stdout);
+      const arr = Array.isArray(parsed) ? parsed : parsed?.workspaces;
+      return Array.isArray(arr) ? (arr as CmuxWorkspace[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Resolve the workspace ref for a session by matching the ghwt-stamped title.
+   * cmux does not enforce title uniqueness - a multi-match is an error, never
+   * a guess (a user manually renaming in the cmux UI is the only realistic
+   * way to break this; ghwt's not-found -> recreate path absorbs that).
+   */
+  private async resolveRef(
+    sessionName: string,
+    workspaces?: CmuxWorkspace[],
+  ): Promise<string | null> {
+    const title = this.workspaceTitle(sessionName);
+    const list = workspaces ?? (await this.listWorkspaces());
+    const matches = list.filter((w) => w.title === title);
+    if (matches.length > 1) {
+      throw new Error(
+        `Ambiguous cmux workspace: ${matches.length} workspaces titled "${title}". ` +
+          `Rename or close the duplicates in cmux.`,
+      );
+    }
+    return matches[0]?.ref ?? null;
+  }
+
+  async sessionExists(sessionName: string, workspaces?: CmuxWorkspace[]): Promise<boolean> {
+    return (await this.resolveRef(sessionName, workspaces)) !== null;
+  }
+
+  /** Send one command line to a surface (cmux unescapes \n and runs it). */
+  private async sendLine(surfaceRef: string, line: string): Promise<void> {
+    if (this.verbose) {
+      console.log(`  $ cmux send ${JSON.stringify(line)} --surface ${surfaceRef}`);
+    }
+    await execa('cmux', ['send', `${line}\n`, '--surface', surfaceRef]);
+  }
+
+  private async newWorkspace(
+    worktreePath: string,
+  ): Promise<{ workspaceRef: string; surfaceRef: string | null }> {
+    const { stdout } = await execa('cmux', ['new-workspace', '--cwd', worktreePath, '--json']);
+    const workspaceRef = parseRef(stdout, 'workspace');
+    if (!workspaceRef) {
+      throw new Error(`cmux new-workspace did not return a workspace ref (got: ${stdout.trim()})`);
+    }
+    // new-workspace may also surface the initial surface ref; capture if present.
+    return { workspaceRef, surfaceRef: parseRef(stdout, 'surface') };
+  }
+
+  private async newSurface(workspaceRef: string): Promise<string> {
+    const { stdout } = await execa('cmux', ['new-surface', '--workspace', workspaceRef, '--json']);
+    const ref = parseRef(stdout, 'surface');
+    if (!ref) {
+      throw new Error(`cmux new-surface did not return a surface ref (got: ${stdout.trim()})`);
+    }
+    return ref;
+  }
+
+  private async newSplit(surfaceRef: string, direction: string): Promise<string> {
+    const { stdout } = await execa('cmux', [
+      'new-split',
+      direction,
+      '--surface',
+      surfaceRef,
+      '--json',
+    ]);
+    const ref = parseRef(stdout, 'surface');
+    if (!ref) {
+      throw new Error(`cmux new-split did not return a surface ref (got: ${stdout.trim()})`);
+    }
+    return ref;
+  }
+
+  /**
+   * Create a cmux workspace mirroring TmuxSessionManager.createSession control
+   * flow: flatten tabs[].windows[].panes[] to a sequence of cmux surfaces in
+   * one workspace. cmux's TabConfig grouping has no analog beyond ordering.
+   * zellij_ui / start_suspended have no cmux analog (ignored, like tmux).
+   */
+  async createSession(
+    sessionName: string,
+    config: SessionConfig,
+    worktreePath: string,
+    project: string,
+    branch: string,
+    notePath?: string,
+  ): Promise<void> {
+    if (await this.sessionExists(sessionName)) {
+      console.log(`⚙️  cmux workspace already exists: ${this.workspaceTitle(sessionName)}`);
+      return;
+    }
+
+    const vars: TemplateVars = {
+      worktree_path: worktreePath,
+      project,
+      branch,
+      note_path: notePath,
+    };
+
+    const normalizedConfig = normalizeSessionConfig(config);
+
+    const { workspaceRef, surfaceRef: initialSurface } = await this.newWorkspace(worktreePath);
+
+    // Stamp the ghwt title (cmux new-workspace has no --name flag; rename does).
+    await execa('cmux', [
+      'rename-workspace',
+      '--workspace',
+      workspaceRef,
+      this.workspaceTitle(sessionName),
+    ]);
+
+    let initialSurfaceFree = initialSurface !== null;
+
+    for (const tab of normalizedConfig.tabs) {
+      for (const window of tab.windows) {
+        const windowRoot = window.root ? join(worktreePath, window.root) : worktreePath;
+        const substitutedRoot = substituteVariables(windowRoot, vars);
+
+        // One window == one cmux surface; extra panes == splits off it.
+        const panes = window.panes && window.panes.length > 0 ? window.panes : [undefined];
+
+        let windowSurface: string;
+        if (initialSurfaceFree && initialSurface) {
+          windowSurface = initialSurface;
+          initialSurfaceFree = false;
+        } else {
+          windowSurface = await this.newSurface(workspaceRef);
+        }
+
+        for (let paneIndex = 0; paneIndex < panes.length; paneIndex++) {
+          const surfaceRef =
+            paneIndex === 0 ? windowSurface : await this.newSplit(windowSurface, 'right');
+
+          // cmux issue #2538: wait for the shell before sending.
+          await delay(surfaceReadyDelayMs());
+
+          // cd into the window root if it differs from the workspace cwd.
+          // Deliberately per-pane, not per-window like the tmux template:
+          // tmux split panes inherit the window cwd; cmux splits do not
+          // reliably, so every surface re-establishes its own dir. Runs
+          // before the pre cascade so pre-commands execute in the right dir
+          // (same ordering as tmux send-keys).
+          if (substitutedRoot !== worktreePath) {
+            await this.sendLine(surfaceRef, `cd ${substitutedRoot}`);
+          }
+
+          // Cascading pre-commands: session -> tab -> window -> pane command.
+          for (const preCmd of normalizedConfig.pre || []) {
+            await this.sendLine(surfaceRef, substituteVariables(preCmd, vars));
+          }
+          for (const preCmd of tab.pre || []) {
+            await this.sendLine(surfaceRef, substituteVariables(preCmd, vars));
+          }
+          for (const preCmd of window.pre || []) {
+            await this.sendLine(surfaceRef, substituteVariables(preCmd, vars));
+          }
+
+          const cmd = panes[paneIndex];
+          if (cmd) {
+            await this.sendLine(surfaceRef, substituteVariables(cmd, vars));
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Ensure the cmux app is running. `cmux ping` tests socket connectivity;
+   * if it fails, try to launch the macOS app and re-probe a few times.
+   */
+  private async ensureAppRunning(): Promise<void> {
+    try {
+      await execa('cmux', ['ping']);
+      return;
+    } catch {
+      // Not running yet - launch the app (cmux analog of `wezterm start`).
+    }
+
+    try {
+      await execa('open', ['-a', 'cmux']);
+    } catch {
+      // `open` may fail if the app isn't installed; surface via ping retries.
+    }
+
+    for (let attempt = 0; attempt < 10; attempt++) {
+      await delay(500);
+      try {
+        await execa('cmux', ['ping']);
+        return;
+      } catch {
+        // keep waiting
+      }
+    }
+    throw new Error('cmux app did not become reachable (is it installed?)');
+  }
+
+  private async select(sessionName: string): Promise<void> {
+    const ref = await this.resolveRef(sessionName);
+    if (!ref) {
+      throw new Error(`cmux workspace not found: ${this.workspaceTitle(sessionName)}`);
+    }
+    if (this.verbose) {
+      console.log(`  $ cmux select-workspace --workspace ${ref}`);
+    }
+    await execa('cmux', ['select-workspace', '--workspace', ref]);
+  }
+
+  /**
+   * Launch/focus cmux on the workspace. terminalUI is intentionally ignored
+   * (cmux is the UI); never spawns wezterm/ghostty.
+   */
+  async launchUI(sessionName: string, _worktreePath: string): Promise<void> {
+    void _worktreePath;
+    await this.ensureAppRunning();
+    await this.select(sessionName);
+  }
+
+  /**
+   * Attach == focus the workspace in cmux. terminalUI / --existing-terminal
+   * are no-ops (ghostty-style). Missing workspace is an error here; the
+   * orchestrator's attach contract recreates before calling attach.
+   */
+  async attachToSession(
+    sessionName: string,
+    _worktreePath: string,
+    _options?: AttachOptions,
+  ): Promise<void> {
+    void _worktreePath;
+    void _options;
+    await this.ensureAppRunning();
+    await this.select(sessionName);
+  }
+
+  async killSession(sessionName: string): Promise<void> {
+    try {
+      const ref = await this.resolveRef(sessionName);
+      if (!ref) return;
+      await execa('cmux', ['close-workspace', '--workspace', ref]);
+    } catch {
+      // Workspace doesn't exist / ambiguous - nothing to kill.
+    }
+  }
+
+  /**
+   * Ring the worktree's cmux workspace (used by the ghwt sync notify bridge).
+   * Best-effort: never throws into the sync path.
+   */
+  async notify(sessionName: string, title: string, subtitle?: string): Promise<void> {
+    try {
+      const ref = await this.resolveRef(sessionName);
+      if (!ref) return;
+      const args = ['notify', '--title', title];
+      if (subtitle) args.push('--subtitle', subtitle);
+      args.push('--workspace', ref);
+      await execa('cmux', args);
+    } catch {
+      // Notification is advisory only.
+    }
+  }
+}

--- a/src/lib/terminal-session-cmux.ts
+++ b/src/lib/terminal-session-cmux.ts
@@ -57,6 +57,13 @@ interface CmuxWorkspace {
   selected?: boolean;
 }
 
+interface CmuxPane {
+  ref: string;
+  index?: number;
+  focused?: boolean;
+  selected_surface_ref?: string;
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -67,15 +74,18 @@ function delay(ms: number): Promise<void> {
  * documented and the tool churns fast, so parse defensively: try JSON with
  * several candidate keys, then fall back to the documented text form.
  */
-function parseRef(stdout: string, kind: 'workspace' | 'surface'): string | null {
+function parseRef(stdout: string, kind: 'workspace' | 'surface' | 'pane'): string | null {
   const trimmed = stdout.trim();
+
+  const candidatesByKind: Record<typeof kind, string[]> = {
+    workspace: ['workspace_ref', 'workspaceRef', 'workspace', 'ref'],
+    surface: ['surface_ref', 'surfaceRef', 'surface', 'ref'],
+    pane: ['pane_ref', 'paneRef', 'pane', 'ref'],
+  };
 
   try {
     const parsed = JSON.parse(trimmed);
-    const candidates =
-      kind === 'workspace'
-        ? ['workspace_ref', 'workspaceRef', 'workspace', 'ref']
-        : ['surface_ref', 'surfaceRef', 'surface', 'ref'];
+    const candidates = candidatesByKind[kind];
     for (const key of candidates) {
       const value = parsed?.[key];
       if (typeof value === 'string' && value.length > 0) {
@@ -110,32 +120,100 @@ function compareVersions(a: [number, number, number], b: [number, number, number
 }
 
 /**
- * Probe cmux: socket alive (`ping`) + version floor (`version`).
- * Throws with an actionable, macOS-only message on any failure.
- * Mirrors the isUIAvailable not-found block in terminal-session.ts.
+ * cmux's error envelope. cmux exits 0 even on failure and prints the error on
+ * stdout/stderr instead, so exit codes are useless - we must sniff output.
+ */
+const CMUX_ERROR_RE = /(^|\n)\s*(Error:|not_found:|invalid_params:|Access denied|Failed to write)/;
+
+/**
+ * Auth-refusal markers. cmux only accepts socket connections from processes it
+ * spawned, unless its (beta) external-access setting is enabled. Without it an
+ * external `cmux` call returns one of these instead of doing anything - and a
+ * misrouted `send` would otherwise land in the user's active workspace.
+ * See manaflow-ai/cmux#1864.
+ */
+const CMUX_AUTH_RE =
+  /Access denied|only processes started inside cmux|Failed to write to socket|Broken pipe/i;
+
+async function cmuxRaw(
+  args: string[],
+): Promise<{ stdout: string; combined: string; spawnFailed: boolean }> {
+  try {
+    const r = await execa('cmux', args, { reject: false });
+    const stdout = r.stdout ?? '';
+    return { stdout, combined: `${stdout}\n${r.stderr ?? ''}`, spawnFailed: false };
+  } catch (e) {
+    // execa only rejects here on spawn failure (binary missing), not on a
+    // non-zero exit (reject:false) - so this is "cmux not found".
+    return { stdout: '', combined: e instanceof Error ? e.message : String(e), spawnFailed: true };
+  }
+}
+
+/**
+ * Run a cmux command, throwing on cmux's error envelope regardless of exit
+ * code. Exit codes are unreliable (cmux returns 0 on errors) and a stale
+ * --workspace ref silently runs in the caller's active workspace, so every
+ * call must be output-checked, not status-checked.
+ */
+async function cmux(args: string[]): Promise<string> {
+  const { stdout, combined, spawnFailed } = await cmuxRaw(args);
+  if (spawnFailed) {
+    throw new Error(`cmux not found / failed to spawn (\`cmux ${args[0]}\`): ${combined.trim()}`);
+  }
+  if (CMUX_ERROR_RE.test(combined)) {
+    const firstErr =
+      combined
+        .split('\n')
+        .map((s) => s.trim())
+        .find((s) =>
+          /^(Error:|not_found:|invalid_params:|Access denied|Failed to write)/.test(s),
+        ) ?? combined.trim();
+    throw new Error(`cmux ${args[0]} failed: ${firstErr}`);
+  }
+  return stdout;
+}
+
+/**
+ * Probe cmux: socket alive + external access allowed (`ping`) + version floor
+ * (`version`). Throws with an actionable message on any failure. Distinguishes
+ * "not installed/running" from "running but refusing external CLI access"
+ * (manaflow-ai/cmux#1864) - the latter needs cmux's external-access setting,
+ * not an install.
  */
 export async function assertCmuxReady(): Promise<void> {
-  try {
-    await execa('cmux', ['ping']);
-  } catch {
+  const ping = await cmuxRaw(['ping']);
+
+  if (ping.spawnFailed) {
     throw new Error(
       `cmux is not reachable (terminalMultiplexer: 'cmux').\n` +
         `   cmux is macOS-only. Install/start it: https://cmux.com (then open the app).`,
     );
   }
+  if (CMUX_AUTH_RE.test(ping.combined)) {
+    throw new Error(
+      `cmux is running but refusing external CLI access (terminalMultiplexer: 'cmux').\n` +
+        `   The cmux backend drives cmux from outside its own terminals, which cmux\n` +
+        `   blocks by default (manaflow-ai/cmux#1864 - no password bypass exists).\n` +
+        `   Enable cmux's external socket access setting, then retry.`,
+    );
+  }
+  if (CMUX_ERROR_RE.test(ping.combined)) {
+    throw new Error(
+      `cmux ping failed (terminalMultiplexer: 'cmux'): ${ping.combined.trim()}\n` +
+        `   cmux is macOS-only. Ensure the app is running: https://cmux.com`,
+    );
+  }
 
-  let versionStdout: string;
-  try {
-    ({ stdout: versionStdout } = await execa('cmux', ['version']));
-  } catch {
+  const version = await cmuxRaw(['version']);
+  if (version.spawnFailed || CMUX_ERROR_RE.test(version.combined)) {
     // `cmux version` itself failed - presence already confirmed by ping, so
     // don't hard-block (older cmux may lack the subcommand).
     return;
   }
 
-  // Comparison + throw live outside the try so a too-old failure can never be
-  // swallowed by the subprocess catch (no message-string sniffing).
-  const got = parseCmuxVersion(versionStdout);
+  // Comparison + throw live outside any catch so a too-old failure can never
+  // be swallowed (no message-string sniffing).
+  const got = parseCmuxVersion(version.stdout);
   const min = parseCmuxVersion(CMUX_MIN_VERSION);
   if (got && min && compareVersions(got, min) < 0) {
     throw new Error(
@@ -157,7 +235,7 @@ export class CmuxSessionManager implements TerminalSessionManager {
 
   private async listWorkspaces(): Promise<CmuxWorkspace[]> {
     try {
-      const { stdout } = await execa('cmux', ['list-workspaces', '--json']);
+      const stdout = await cmux(['list-workspaces', '--json']);
       const parsed = JSON.parse(stdout);
       const arr = Array.isArray(parsed) ? parsed : parsed?.workspaces;
       return Array.isArray(arr) ? (arr as CmuxWorkspace[]) : [];
@@ -192,55 +270,76 @@ export class CmuxSessionManager implements TerminalSessionManager {
     return (await this.resolveRef(sessionName, workspaces)) !== null;
   }
 
-  /** Send one command line to a surface (cmux unescapes \n and runs it). */
-  private async sendLine(surfaceRef: string, line: string): Promise<void> {
+  /**
+   * Send one command line to the workspace's focused pane.
+   *
+   * Addressed by --workspace, NOT --surface: `cmux send --surface <ref>` is
+   * rejected with "Surface is not a terminal" even for the live, selected,
+   * tty-backed surface (verified against cmux 0.64.6). `--workspace` routes to
+   * the focused pane's active surface, so callers must focusPane() first.
+   * (cmux unescapes \n and runs the line.)
+   */
+  private async sendLine(workspaceRef: string, line: string): Promise<void> {
     if (this.verbose) {
-      console.log(`  $ cmux send ${JSON.stringify(line)} --surface ${surfaceRef}`);
+      console.log(`  $ cmux send ${JSON.stringify(line)} --workspace ${workspaceRef}`);
     }
-    await execa('cmux', ['send', `${line}\n`, '--surface', surfaceRef]);
+    await cmux(['send', `${line}\n`, '--workspace', workspaceRef]);
   }
 
-  private async newWorkspace(
-    worktreePath: string,
-  ): Promise<{ workspaceRef: string; surfaceRef: string | null }> {
-    const { stdout } = await execa('cmux', ['new-workspace', '--cwd', worktreePath, '--json']);
+  private async newWorkspace(worktreePath: string): Promise<string> {
+    const stdout = await cmux(['new-workspace', '--cwd', worktreePath, '--json']);
     const workspaceRef = parseRef(stdout, 'workspace');
     if (!workspaceRef) {
       throw new Error(`cmux new-workspace did not return a workspace ref (got: ${stdout.trim()})`);
     }
-    // new-workspace may also surface the initial surface ref; capture if present.
-    return { workspaceRef, surfaceRef: parseRef(stdout, 'surface') };
+    return workspaceRef;
   }
 
-  private async newSurface(workspaceRef: string): Promise<string> {
-    const { stdout } = await execa('cmux', ['new-surface', '--workspace', workspaceRef, '--json']);
-    const ref = parseRef(stdout, 'surface');
+  /** List a workspace's panes (the addressable terminal containers). */
+  private async listPanes(workspaceRef: string): Promise<CmuxPane[]> {
+    try {
+      const stdout = await cmux(['list-panes', '--workspace', workspaceRef, '--json']);
+      const parsed = JSON.parse(stdout);
+      const arr = Array.isArray(parsed) ? parsed : parsed?.panes;
+      return Array.isArray(arr) ? (arr as CmuxPane[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Split the workspace's active pane; returns the NEW pane's ref.
+   * `cmux new-split` has no --pane flag, so callers focusPane() the pane they
+   * want to split immediately before calling this. Each ghwt pane maps to a
+   * cmux pane (a live terminal), not a stacked surface.
+   */
+  private async newSplitPane(workspaceRef: string, direction: string): Promise<string> {
+    const stdout = await cmux(['new-split', direction, '--workspace', workspaceRef, '--json']);
+    const ref = parseRef(stdout, 'pane');
     if (!ref) {
-      throw new Error(`cmux new-surface did not return a surface ref (got: ${stdout.trim()})`);
+      throw new Error(`cmux new-split did not return a pane ref (got: ${stdout.trim()})`);
     }
     return ref;
   }
 
-  private async newSplit(surfaceRef: string, direction: string): Promise<string> {
-    const { stdout } = await execa('cmux', [
-      'new-split',
-      direction,
-      '--surface',
-      surfaceRef,
-      '--json',
-    ]);
-    const ref = parseRef(stdout, 'surface');
-    if (!ref) {
-      throw new Error(`cmux new-split did not return a surface ref (got: ${stdout.trim()})`);
+  /** Focus a pane so a subsequent --workspace send/split targets it. */
+  private async focusPane(paneRef: string, workspaceRef: string): Promise<void> {
+    if (this.verbose) {
+      console.log(`  $ cmux focus-pane --pane ${paneRef} --workspace ${workspaceRef}`);
     }
-    return ref;
+    // Hardened cmux() throws on cmux's "not_found: Pane not found" envelope
+    // (which cmux returns with exit 0), so a cross-workspace/stale pane fails
+    // loudly here instead of letting the next send misroute.
+    await cmux(['focus-pane', '--pane', paneRef, '--workspace', workspaceRef]);
   }
 
   /**
    * Create a cmux workspace mirroring TmuxSessionManager.createSession control
-   * flow: flatten tabs[].windows[].panes[] to a sequence of cmux surfaces in
-   * one workspace. cmux's TabConfig grouping has no analog beyond ordering.
-   * zellij_ui / start_suspended have no cmux analog (ignored, like tmux).
+   * flow: flatten tabs[].windows[].panes[] to a sequence of cmux *panes* (each
+   * a live terminal) in one workspace. cmux's TabConfig grouping has no analog
+   * beyond ordering. zellij_ui / start_suspended have no cmux analog (ignored,
+   * like tmux). Surfaces are NOT used: new-surface stacks non-live views inside
+   * one pane; only panes are independently sendable.
    */
   async createSession(
     sessionName: string,
@@ -264,65 +363,74 @@ export class CmuxSessionManager implements TerminalSessionManager {
 
     const normalizedConfig = normalizeSessionConfig(config);
 
-    const { workspaceRef, surfaceRef: initialSurface } = await this.newWorkspace(worktreePath);
+    const workspaceRef = await this.newWorkspace(worktreePath);
 
     // Stamp the ghwt title (cmux new-workspace has no --name flag; rename does).
-    await execa('cmux', [
-      'rename-workspace',
-      '--workspace',
-      workspaceRef,
-      this.workspaceTitle(sessionName),
-    ]);
+    await cmux(['rename-workspace', '--workspace', workspaceRef, this.workspaceTitle(sessionName)]);
 
-    let initialSurfaceFree = initialSurface !== null;
+    // The workspace is created with one initial pane (a live terminal); reuse
+    // it for the first ghwt pane, then split for each subsequent one.
+    // Misroute guard: a freshly created workspace MUST have >= 1 pane. Zero
+    // means workspaceRef is stale/invalid - sending into it would silently
+    // run in the user's active workspace (cmux `send` falls back, not errors),
+    // so abort rather than risk executing the session in the wrong place.
+    const initialPanes = await this.listPanes(workspaceRef);
+    if (initialPanes.length === 0) {
+      throw new Error(
+        `cmux workspace ${workspaceRef} reports no panes right after creation; ` +
+          `aborting to avoid running the session in the wrong workspace.`,
+      );
+    }
+    let initialPane: string | null = initialPanes[0]?.ref ?? null;
 
     for (const tab of normalizedConfig.tabs) {
       for (const window of tab.windows) {
         const windowRoot = window.root ? join(worktreePath, window.root) : worktreePath;
         const substitutedRoot = substituteVariables(windowRoot, vars);
 
-        // One window == one cmux surface; extra panes == splits off it.
+        // Each ghwt pane (or a window with none) maps to one cmux pane.
         const panes = window.panes && window.panes.length > 0 ? window.panes : [undefined];
 
-        let windowSurface: string;
-        if (initialSurfaceFree && initialSurface) {
-          windowSurface = initialSurface;
-          initialSurfaceFree = false;
-        } else {
-          windowSurface = await this.newSurface(workspaceRef);
-        }
-
         for (let paneIndex = 0; paneIndex < panes.length; paneIndex++) {
-          const surfaceRef =
-            paneIndex === 0 ? windowSurface : await this.newSplit(windowSurface, 'right');
+          let paneRef: string;
+          if (initialPane) {
+            paneRef = initialPane;
+            initialPane = null;
+          } else {
+            // new-split has no --pane; it splits the active pane. The previous
+            // iteration focused the last pane, so the split chains off it.
+            paneRef = await this.newSplitPane(workspaceRef, 'right');
+          }
+
+          // Focus so the --workspace-addressed sends below land in this pane.
+          await this.focusPane(paneRef, workspaceRef);
 
           // cmux issue #2538: wait for the shell before sending.
           await delay(surfaceReadyDelayMs());
 
           // cd into the window root if it differs from the workspace cwd.
-          // Deliberately per-pane, not per-window like the tmux template:
-          // tmux split panes inherit the window cwd; cmux splits do not
-          // reliably, so every surface re-establishes its own dir. Runs
-          // before the pre cascade so pre-commands execute in the right dir
-          // (same ordering as tmux send-keys).
+          // Per-pane (not per-window like the tmux template): cmux split panes
+          // do not reliably inherit a cwd, so every pane re-establishes its
+          // own dir. Runs before the pre cascade so pre-commands execute in
+          // the right dir (same ordering as tmux send-keys).
           if (substitutedRoot !== worktreePath) {
-            await this.sendLine(surfaceRef, `cd ${substitutedRoot}`);
+            await this.sendLine(workspaceRef, `cd ${substitutedRoot}`);
           }
 
           // Cascading pre-commands: session -> tab -> window -> pane command.
           for (const preCmd of normalizedConfig.pre || []) {
-            await this.sendLine(surfaceRef, substituteVariables(preCmd, vars));
+            await this.sendLine(workspaceRef, substituteVariables(preCmd, vars));
           }
           for (const preCmd of tab.pre || []) {
-            await this.sendLine(surfaceRef, substituteVariables(preCmd, vars));
+            await this.sendLine(workspaceRef, substituteVariables(preCmd, vars));
           }
           for (const preCmd of window.pre || []) {
-            await this.sendLine(surfaceRef, substituteVariables(preCmd, vars));
+            await this.sendLine(workspaceRef, substituteVariables(preCmd, vars));
           }
 
           const cmd = panes[paneIndex];
           if (cmd) {
-            await this.sendLine(surfaceRef, substituteVariables(cmd, vars));
+            await this.sendLine(workspaceRef, substituteVariables(cmd, vars));
           }
         }
       }
@@ -334,13 +442,20 @@ export class CmuxSessionManager implements TerminalSessionManager {
    * if it fails, try to launch the macOS app and re-probe a few times.
    */
   private async ensureAppRunning(): Promise<void> {
-    try {
-      await execa('cmux', ['ping']);
-      return;
-    } catch {
-      // Not running yet - launch the app (cmux analog of `wezterm start`).
+    const probe = await cmuxRaw(['ping']);
+    // Auth refusal means cmux IS running - relaunching won't help, and the
+    // real problem (external-access setting) needs assertCmuxReady's message.
+    if (CMUX_AUTH_RE.test(probe.combined)) {
+      throw new Error(
+        `cmux is running but refusing external CLI access (manaflow-ai/cmux#1864). ` +
+          `Enable cmux's external socket access setting, then retry.`,
+      );
+    }
+    if (!probe.spawnFailed && !CMUX_ERROR_RE.test(probe.combined)) {
+      return; // reachable
     }
 
+    // Not running yet - launch the app (cmux analog of `wezterm start`).
     try {
       await execa('open', ['-a', 'cmux']);
     } catch {
@@ -349,11 +464,15 @@ export class CmuxSessionManager implements TerminalSessionManager {
 
     for (let attempt = 0; attempt < 10; attempt++) {
       await delay(500);
-      try {
-        await execa('cmux', ['ping']);
+      const retry = await cmuxRaw(['ping']);
+      if (CMUX_AUTH_RE.test(retry.combined)) {
+        throw new Error(
+          `cmux is running but refusing external CLI access (manaflow-ai/cmux#1864). ` +
+            `Enable cmux's external socket access setting, then retry.`,
+        );
+      }
+      if (!retry.spawnFailed && !CMUX_ERROR_RE.test(retry.combined)) {
         return;
-      } catch {
-        // keep waiting
       }
     }
     throw new Error('cmux app did not become reachable (is it installed?)');
@@ -367,7 +486,7 @@ export class CmuxSessionManager implements TerminalSessionManager {
     if (this.verbose) {
       console.log(`  $ cmux select-workspace --workspace ${ref}`);
     }
-    await execa('cmux', ['select-workspace', '--workspace', ref]);
+    await cmux(['select-workspace', '--workspace', ref]);
   }
 
   /**
@@ -400,7 +519,7 @@ export class CmuxSessionManager implements TerminalSessionManager {
     try {
       const ref = await this.resolveRef(sessionName);
       if (!ref) return;
-      await execa('cmux', ['close-workspace', '--workspace', ref]);
+      await cmux(['close-workspace', '--workspace', ref]);
     } catch {
       // Workspace doesn't exist / ambiguous - nothing to kill.
     }
@@ -417,7 +536,7 @@ export class CmuxSessionManager implements TerminalSessionManager {
       const args = ['notify', '--title', title];
       if (subtitle) args.push('--subtitle', subtitle);
       args.push('--workspace', ref);
-      await execa('cmux', args);
+      await cmux(args);
     } catch {
       // Notification is advisory only.
     }

--- a/src/lib/terminal-session-herdr.ts
+++ b/src/lib/terminal-session-herdr.ts
@@ -1,0 +1,555 @@
+import { execa } from 'execa';
+import { join } from 'path';
+import { GhwtConfig } from '../types.js';
+import {
+  TerminalSessionManager,
+  SessionConfig,
+  TemplateVars,
+  AttachOptions,
+  AgentStatus,
+  substituteVariables,
+  normalizeSessionConfig,
+  launchGhostty,
+} from './terminal-session-base.js';
+
+/**
+ * herdr session backend (opt-in via terminalMultiplexer: 'herdr').
+ *
+ * Arms-length integration: this adapter shells out to the `herdr` binary only.
+ * No linking, no socket parsing beyond herdr's documented JSON CLI output. All
+ * herdr-specific behavior is quarantined here so the rest of ghwt stays
+ * portable and MIT-clean. (herdr itself is AGPL-3.0; shelling out to a separate
+ * binary via execa is not linking and does not affect ghwt's MIT license.)
+ *
+ * Why herdr is a much thinner adapter than the cmux one (validated against
+ * herdr 0.5.10 on macOS, server protocol 6):
+ *   - `workspace create` returns the workspace_id AND root pane_id directly,
+ *     so there is no "no deterministic addressing -> stamp a title and resolve
+ *     fresh every call" dance. We still resolve by label (a workspace is the
+ *     per-worktree unit, same as cmux) but only because herdr ids are not
+ *     stable across server restarts; the create path needs no round-trip.
+ *   - `pane run <pane_id> <cmd>` executes a command in a specific pane: no
+ *     missing --command flag, so NO shell-not-ready fixed-sleep race hack.
+ *   - `pane split <pane_id> --direction right --cwd PATH` addresses a specific
+ *     pane and sets its cwd: no focus-first hack, no per-pane re-`cd` hack.
+ *   - herdr exits non-zero on failure AND emits {"error":{code,message}}: no
+ *     "exit 0 on error, sniff stdout with regexes" hack.
+ *   - The control socket is the documented interface for external agents, so
+ *     there is no cmux-#1864-style "refuses processes it didn't spawn" wall.
+ *
+ * herdr is a TUI multiplexer (like tmux/zellij), not a fused GUI (like cmux):
+ * session/workspace management is CLI-driven (cmux-like) but attaching is done
+ * by running `herdr` in a terminal (tmux/zellij-like), so `terminalUI`
+ * (wezterm/ghostty/none) IS honored here, unlike the cmux backend.
+ *
+ * herdr exposes no external notification trigger (no `herdr notify`; it detects
+ * agent state itself and self-notifies), so this backend deliberately omits the
+ * optional `notify` method - the sync notify bridge no-ops for herdr exactly as
+ * it does for tmux/zellij. herdr's own per-pane agent-state detection is the
+ * intended attention signal; wiring that into ghwt's needs-attention model is a
+ * separate, follow-up integration.
+ */
+
+/**
+ * Minimum supported herdr. herdr churns fast with breaking protocol bumps
+ * between patch releases; this is the version this adapter was validated
+ * against (server protocol 6). Unparseable version strings are accepted (the
+ * session-list readiness probe already proves a compatible server is up).
+ */
+export const HERDR_MIN_VERSION = '0.5.10';
+
+/** Label namespace so ghwt-managed workspaces don't collide with user-created ones. */
+const LABEL_PREFIX = 'ghwt:';
+
+/**
+ * Roll-up urgency when a session has >1 agent: the most-urgent state wins.
+ * 'blocked' (agent waiting on the human) is the one ghwt's needs-attention
+ * model keys on, so it must rank highest.
+ *
+ * `done` is intentionally kept: herdr 0.5.10's `report-agent`/`agent wait`
+ * enums document only idle|working|blocked|unknown, but real `herdr workspace
+ * list` / `agent list` output was observed emitting `agent_status: "done"` at
+ * runtime (probed against a live workspace). The enum docs are herdr's own
+ * inconsistency - do not drop `done` to "match the docs"; it occurs.
+ */
+const STATUS_RANK: Record<AgentStatus, number> = {
+  blocked: 4,
+  working: 3,
+  done: 2,
+  idle: 1,
+  unknown: 0,
+};
+
+function normalizeStatus(raw: unknown): AgentStatus {
+  return raw === 'blocked' || raw === 'working' || raw === 'done' || raw === 'idle'
+    ? raw
+    : 'unknown';
+}
+
+interface HerdrWorkspace {
+  workspace_id: string;
+  label?: string;
+  agent_status?: string;
+}
+
+async function herdrRaw(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number; spawnFailed: boolean; combined: string }> {
+  try {
+    const r = await execa('herdr', args, { reject: false });
+    const stdout = r.stdout ?? '';
+    return {
+      stdout,
+      exitCode: r.exitCode ?? 0,
+      spawnFailed: false,
+      combined: `${stdout}\n${r.stderr ?? ''}`,
+    };
+  } catch (e) {
+    // execa only rejects here on spawn failure (binary missing), not on a
+    // non-zero exit (reject:false) - so this is "herdr not found".
+    return {
+      stdout: '',
+      exitCode: -1,
+      spawnFailed: true,
+      combined: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+/**
+ * Pull herdr's structured error message out of JSON output, if present.
+ * herdr emits {"error":{"code":"...","message":"..."}} on failures.
+ */
+function herdrErrorMessage(stdout: string): string | null {
+  try {
+    const parsed = JSON.parse(stdout.trim());
+    const err = parsed?.error;
+    if (err && typeof err === 'object') {
+      const code = typeof err.code === 'string' ? err.code : '';
+      const message = typeof err.message === 'string' ? err.message : '';
+      return [code, message].filter(Boolean).join(': ') || JSON.stringify(err);
+    }
+  } catch {
+    // Not JSON / no error envelope.
+  }
+  return null;
+}
+
+/**
+ * Run a herdr command. Throws on spawn failure, non-zero exit, or a
+ * {"error":...} envelope. herdr's exit codes are reliable (unlike cmux), so
+ * this is a straightforward status + structured-error check - no regex
+ * output sniffing.
+ */
+async function herdr(args: string[]): Promise<string> {
+  const { stdout, exitCode, spawnFailed, combined } = await herdrRaw(args);
+  if (spawnFailed) {
+    throw new Error(`herdr not found / failed to spawn (\`herdr ${args[0]}\`): ${combined.trim()}`);
+  }
+  const errMsg = herdrErrorMessage(stdout);
+  if (exitCode !== 0 || errMsg) {
+    const detail = errMsg ?? (combined.trim() || `exit ${exitCode}`);
+    throw new Error(`herdr ${args[0]} failed: ${detail}`);
+  }
+  return stdout;
+}
+
+/** Unwrap herdr's `{"id":...,"result":{...}}` envelope; throws if absent. */
+function resultOf(stdout: string, context: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout.trim());
+  } catch {
+    throw new Error(`herdr ${context}: expected JSON, got: ${stdout.trim().slice(0, 200)}`);
+  }
+  const result = (parsed as { result?: unknown })?.result;
+  if (!result || typeof result !== 'object') {
+    throw new Error(`herdr ${context}: missing "result" in: ${stdout.trim().slice(0, 200)}`);
+  }
+  return result as Record<string, unknown>;
+}
+
+/** Parse `herdr --version` ("herdr 0.5.10") into a comparable tuple. */
+export function parseHerdrVersion(versionOutput: string): [number, number, number] | null {
+  const match = versionOutput.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareVersions(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+/**
+ * Probe herdr: binary present + the default session's background server is
+ * running + version floor. herdr is client-server; every workspace/pane call
+ * talks to that server's socket, so a down server must fail fast with an
+ * actionable message (ghwt does not auto-spawn herdr's TUI server - the user
+ * runs `herdr` themselves). Uses `herdr session list --json` (the `--json`
+ * flag is required here: bare `session list` prints a human table, unlike
+ * `workspace list` which is JSON by default - herdr's flag convention is
+ * per-command and inconsistent).
+ */
+export async function assertHerdrReady(): Promise<void> {
+  const version = await herdrRaw(['--version']);
+  if (version.spawnFailed) {
+    throw new Error(
+      `herdr is not reachable (terminalMultiplexer: 'herdr').\n` +
+        `   Install it (Linux/macOS): curl -fsSL https://herdr.dev/install.sh | sh`,
+    );
+  }
+
+  const list = await herdrRaw(['session', 'list', '--json']);
+  let serverRunning = false;
+  if (!list.spawnFailed && list.exitCode === 0) {
+    try {
+      const parsed = JSON.parse(list.stdout.trim()) as {
+        sessions?: Array<{ default?: boolean; running?: boolean }>;
+      };
+      const sessions = Array.isArray(parsed.sessions) ? parsed.sessions : [];
+      const def = sessions.find((s) => s.default) ?? sessions[0];
+      serverRunning = def?.running === true;
+    } catch {
+      // Unparseable - treat as not running (handled below).
+    }
+  }
+  if (!serverRunning) {
+    throw new Error(
+      `herdr is installed but its background server is not running ` +
+        `(terminalMultiplexer: 'herdr').\n` +
+        `   Start it by running \`herdr\` in a terminal once, then retry.`,
+    );
+  }
+
+  // Comparison + throw outside any catch so a too-old failure can't be
+  // swallowed. Unparseable version: server liveness already proven, accept it.
+  const got = parseHerdrVersion(version.stdout);
+  const min = parseHerdrVersion(HERDR_MIN_VERSION);
+  if (got && min && compareVersions(got, min) < 0) {
+    throw new Error(
+      `herdr ${got.join('.')} is too old; ghwt needs >= ${HERDR_MIN_VERSION}. Run \`herdr update\`.`,
+    );
+  }
+}
+
+export class HerdrSessionManager implements TerminalSessionManager {
+  constructor(
+    private config?: GhwtConfig,
+    private verbose = false,
+  ) {}
+
+  private workspaceLabel(sessionName: string): string {
+    return `${LABEL_PREFIX}${sessionName}`;
+  }
+
+  private async listWorkspaces(): Promise<HerdrWorkspace[]> {
+    try {
+      const result = resultOf(await herdr(['workspace', 'list']), 'workspace list');
+      const arr = result.workspaces;
+      return Array.isArray(arr) ? (arr as HerdrWorkspace[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Resolve the workspace id for a session by matching the ghwt-stamped label.
+   * herdr does not enforce label uniqueness - a multi-match is an error, never
+   * a guess (ghwt's not-found -> recreate path absorbs a user-renamed dup).
+   */
+  private async resolveId(
+    sessionName: string,
+    workspaces?: HerdrWorkspace[],
+  ): Promise<string | null> {
+    const label = this.workspaceLabel(sessionName);
+    const list = workspaces ?? (await this.listWorkspaces());
+    const matches = list.filter((w) => w.label === label);
+    if (matches.length > 1) {
+      throw new Error(
+        `Ambiguous herdr workspace: ${matches.length} workspaces labelled "${label}". ` +
+          `Rename or close the duplicates in herdr.`,
+      );
+    }
+    return matches[0]?.workspace_id ?? null;
+  }
+
+  async sessionExists(sessionName: string, workspaces?: HerdrWorkspace[]): Promise<boolean> {
+    return (await this.resolveId(sessionName, workspaces)) !== null;
+  }
+
+  /** Run one command line in a specific pane (herdr executes it in the shell). */
+  private async runInPane(paneId: string, line: string): Promise<void> {
+    if (this.verbose) {
+      console.log(`  $ herdr pane run ${paneId} ${JSON.stringify(line)}`);
+    }
+    await herdr(['pane', 'run', paneId, line]);
+  }
+
+  /**
+   * Create the workspace; returns its id and the initial (root) pane id, both
+   * straight from herdr's `workspace_created` payload - no list round-trip.
+   */
+  private async newWorkspace(
+    worktreePath: string,
+    label: string,
+  ): Promise<{ workspaceId: string; rootPaneId: string }> {
+    const result = resultOf(
+      await herdr(['workspace', 'create', '--cwd', worktreePath, '--label', label, '--no-focus']),
+      'workspace create',
+    );
+    const workspace = result.workspace as { workspace_id?: string } | undefined;
+    const rootPane = result.root_pane as { pane_id?: string } | undefined;
+    const workspaceId = workspace?.workspace_id;
+    const rootPaneId = rootPane?.pane_id;
+    if (!workspaceId || !rootPaneId) {
+      throw new Error(
+        `herdr workspace create did not return workspace_id + root pane_id ` +
+          `(got: ${JSON.stringify(result).slice(0, 200)})`,
+      );
+    }
+    return { workspaceId, rootPaneId };
+  }
+
+  /** Split a specific pane; returns the NEW pane's id. */
+  private async splitPane(paneId: string, cwd: string): Promise<string> {
+    const result = resultOf(
+      await herdr(['pane', 'split', paneId, '--direction', 'right', '--cwd', cwd, '--no-focus']),
+      'pane split',
+    );
+    const pane = result.pane as { pane_id?: string } | undefined;
+    if (!pane?.pane_id) {
+      throw new Error(
+        `herdr pane split did not return a pane id (got: ${JSON.stringify(result).slice(0, 200)})`,
+      );
+    }
+    return pane.pane_id;
+  }
+
+  /**
+   * Create a herdr workspace mirroring the cmux backend's control flow:
+   * flatten tabs[].windows[].panes[] to a sequence of herdr panes in one
+   * workspace. herdr has real tabs, but flattening keeps the two newest
+   * backends consistent and matches the cmux precedent; window->tab mapping
+   * is a possible later refinement. zellij_ui / start_suspended have no herdr
+   * analog (ignored, like tmux/cmux).
+   */
+  async createSession(
+    sessionName: string,
+    config: SessionConfig,
+    worktreePath: string,
+    project: string,
+    branch: string,
+    notePath?: string,
+  ): Promise<void> {
+    if (await this.sessionExists(sessionName)) {
+      console.log(`⚙️  herdr workspace already exists: ${this.workspaceLabel(sessionName)}`);
+      return;
+    }
+
+    const vars: TemplateVars = {
+      worktree_path: worktreePath,
+      project,
+      branch,
+      note_path: notePath,
+    };
+
+    const normalizedConfig = normalizeSessionConfig(config);
+
+    const { workspaceId, rootPaneId } = await this.newWorkspace(
+      worktreePath,
+      this.workspaceLabel(sessionName),
+    );
+    if (this.verbose) {
+      console.log(`  herdr workspace ${workspaceId} (root pane ${rootPaneId})`);
+    }
+
+    // The workspace starts with one live pane; reuse it for the first ghwt
+    // pane, then split off the previous pane for each subsequent one (chained,
+    // same layout strategy as the cmux backend).
+    let initialPane: string | null = rootPaneId;
+    let lastPaneId = rootPaneId;
+
+    for (const tab of normalizedConfig.tabs) {
+      for (const window of tab.windows) {
+        const windowRoot = window.root ? join(worktreePath, window.root) : worktreePath;
+        const substitutedRoot = substituteVariables(windowRoot, vars);
+
+        // Each ghwt pane (or a window with none) maps to one herdr pane.
+        const panes = window.panes && window.panes.length > 0 ? window.panes : [undefined];
+
+        for (let paneIndex = 0; paneIndex < panes.length; paneIndex++) {
+          let paneId: string;
+          if (initialPane) {
+            paneId = initialPane;
+            initialPane = null;
+            // The root pane's cwd is the workspace cwd (worktreePath); only
+            // re-cd it if this window wants a different root. Split panes get
+            // their cwd via --cwd, so this is the one place a cd is needed.
+            if (substitutedRoot !== worktreePath) {
+              await this.runInPane(paneId, `cd ${substitutedRoot}`);
+            }
+          } else {
+            paneId = await this.splitPane(lastPaneId, substitutedRoot);
+          }
+          lastPaneId = paneId;
+
+          // Cascading pre-commands: session -> tab -> window -> pane command.
+          for (const preCmd of normalizedConfig.pre || []) {
+            await this.runInPane(paneId, substituteVariables(preCmd, vars));
+          }
+          for (const preCmd of tab.pre || []) {
+            await this.runInPane(paneId, substituteVariables(preCmd, vars));
+          }
+          for (const preCmd of window.pre || []) {
+            await this.runInPane(paneId, substituteVariables(preCmd, vars));
+          }
+
+          const cmd = panes[paneIndex];
+          if (cmd) {
+            await this.runInPane(paneId, substituteVariables(cmd, vars));
+          }
+        }
+      }
+    }
+  }
+
+  /** Focus the workspace so an attaching herdr client lands on it. Best-effort. */
+  private async focusWorkspace(sessionName: string): Promise<void> {
+    try {
+      const id = await this.resolveId(sessionName);
+      if (!id) return;
+      if (this.verbose) {
+        console.log(`  $ herdr workspace focus ${id}`);
+      }
+      await herdr(['workspace', 'focus', id]);
+    } catch {
+      // Focus is advisory - attaching still works without it.
+    }
+  }
+
+  /**
+   * Attach a herdr TUI client (optionally wrapped in wezterm/ghostty), with
+   * the target workspace pre-focused. herdr is a TUI multiplexer, so this
+   * mirrors the tmux/zellij launch flow rather than the cmux GUI flow.
+   */
+  async launchUI(sessionName: string, worktreePath: string): Promise<void> {
+    await this.focusWorkspace(sessionName);
+    const ui = this.config?.terminalUI || 'wezterm';
+
+    if (ui === 'wezterm') {
+      await execa('wezterm', [
+        'start',
+        '--workspace',
+        sessionName,
+        '--cwd',
+        worktreePath,
+        '--',
+        'herdr',
+      ]);
+    } else if (ui === 'ghostty') {
+      await launchGhostty(['-e', 'herdr']);
+    } else {
+      // 'none' / unknown: attach herdr directly in the current terminal.
+      await execa('herdr', [], { cwd: worktreePath, stdio: 'inherit' });
+    }
+  }
+
+  /**
+   * Attach to the workspace. The orchestrator's attach contract recreates a
+   * missing session before calling attach, so a missing workspace here is an
+   * error (mirrors tmux/zellij/cmux).
+   */
+  async attachToSession(
+    sessionName: string,
+    worktreePath: string,
+    options?: AttachOptions,
+  ): Promise<void> {
+    const exists = await this.sessionExists(sessionName);
+    if (!exists) {
+      throw new Error(`herdr workspace not found: ${this.workspaceLabel(sessionName)}`);
+    }
+    await this.focusWorkspace(sessionName);
+    const ui = this.config?.terminalUI || 'wezterm';
+
+    try {
+      if (ui === 'wezterm') {
+        const weztermArgs = ['start', '--workspace', sessionName, '--cwd', worktreePath];
+        if (options?.alwaysNewProcess !== false) {
+          weztermArgs.push('--always-new-process');
+        }
+        weztermArgs.push('--', 'herdr');
+        await execa('wezterm', weztermArgs, { stdio: 'inherit' });
+      } else if (ui === 'ghostty') {
+        await launchGhostty(['-e', 'herdr'], { stdio: 'inherit' });
+      } else {
+        await execa('herdr', [], { cwd: worktreePath, stdio: 'inherit' });
+      }
+    } catch {
+      // UI app unavailable - fall back to a direct herdr attach.
+      console.log(`📋 Attaching to herdr in current terminal...`);
+      await execa('herdr', [], { cwd: worktreePath, stdio: 'inherit' });
+    }
+  }
+
+  async killSession(sessionName: string): Promise<void> {
+    try {
+      const id = await this.resolveId(sessionName);
+      if (!id) return;
+      await herdr(['workspace', 'close', id]);
+    } catch {
+      // Workspace doesn't exist / ambiguous - nothing to kill.
+    }
+  }
+
+  /**
+   * Map ghwt session name -> most-urgent live agent status, by joining
+   * `herdr agent list` (agent_status + workspace_id) to `herdr workspace list`
+   * (workspace_id -> ghwt-stamped label). Only ghwt-labelled workspaces are
+   * reported; herdr workspaces the user created themselves (unprefixed) are
+   * intentionally not adopted. Best-effort: any failure -> empty map, so an
+   * advisory signal never breaks a sync.
+   */
+  async agentStatuses(): Promise<Map<string, AgentStatus> | null> {
+    try {
+      const result = new Map<string, AgentStatus>();
+
+      // listWorkspaces() swallows internally and returns []; an empty list is
+      // ambiguous (no workspaces vs herdr down), so probe the agent list with
+      // the throwing herdr() first - a hard failure here -> null (don't wipe).
+      const agentResult = resultOf(await herdr(['agent', 'list']), 'agent list');
+
+      const workspaces = await this.listWorkspaces();
+      const labelById = new Map<string, string>();
+      for (const w of workspaces) {
+        if (w.workspace_id && typeof w.label === 'string') {
+          labelById.set(w.workspace_id, w.label);
+        }
+      }
+
+      const agents = Array.isArray(agentResult.agents)
+        ? (agentResult.agents as Array<{ agent_status?: unknown; workspace_id?: unknown }>)
+        : [];
+
+      for (const a of agents) {
+        const wsId = typeof a.workspace_id === 'string' ? a.workspace_id : undefined;
+        const label = wsId ? labelById.get(wsId) : undefined;
+        if (!label || !label.startsWith(LABEL_PREFIX)) continue;
+        const sessionName = label.slice(LABEL_PREFIX.length);
+        const status = normalizeStatus(a.agent_status);
+        const prev = result.get(sessionName);
+        if (!prev || STATUS_RANK[status] > STATUS_RANK[prev]) {
+          result.set(sessionName, status);
+        }
+      }
+      return result;
+    } catch {
+      // Could not determine (herdr unreachable / CLI error). null tells sync
+      // to leave the existing agent_status untouched rather than mass-clear
+      // every session on a transient outage.
+      return null;
+    }
+  }
+}

--- a/src/lib/terminal-session.ts
+++ b/src/lib/terminal-session.ts
@@ -10,12 +10,14 @@ import {
   TerminalSessionManager,
   isUIAvailable,
   isCmuxAvailable,
+  isHerdrAvailable,
 } from './terminal-session-base.js';
 import { validateSessionConfig } from './schemas.js';
 import { getSessionName } from './paths.js';
 import { TmuxSessionManager } from './terminal-session-tmux.js';
 import { ZellijSessionManager } from './terminal-session-zellij.js';
 import { CmuxSessionManager, assertCmuxReady } from './terminal-session-cmux.js';
+import { HerdrSessionManager, assertHerdrReady } from './terminal-session-herdr.js';
 
 // Re-export for compatibility
 export type { SessionConfig, WindowConfig, TabConfig };
@@ -84,6 +86,8 @@ export function getSessionManager(config: GhwtConfig, verbose = false): Terminal
       return new ZellijSessionManager(config, verbose);
     case 'cmux':
       return new CmuxSessionManager(config, verbose);
+    case 'herdr':
+      return new HerdrSessionManager(config, verbose);
     default:
       return new TmuxSessionManager(config, verbose);
   }
@@ -104,6 +108,18 @@ async function assertSessionBackendReady(config: GhwtConfig): Promise<void> {
     }
     await assertCmuxReady();
     return;
+  }
+
+  if (config.terminalMultiplexer === 'herdr') {
+    const available = await isHerdrAvailable();
+    if (!available) {
+      console.warn(`⚠️  herdr not found in PATH (terminalMultiplexer: 'herdr').`);
+      console.warn(`   Install it: curl -fsSL https://herdr.dev/install.sh | sh`);
+      throw new Error(`herdr is not available`);
+    }
+    await assertHerdrReady();
+    // No early return: herdr is a TUI multiplexer attached via the terminal UI
+    // app (like tmux/zellij), so the terminalUI check below still applies.
   }
 
   const ui = (config.terminalUI || 'wezterm') as 'wezterm' | 'ghostty' | 'none';
@@ -213,7 +229,8 @@ export async function attachCommand(
     if (
       (ui === 'wezterm' || ui === 'ghostty') &&
       config.terminalMultiplexer !== 'zellij' &&
-      config.terminalMultiplexer !== 'cmux'
+      config.terminalMultiplexer !== 'cmux' &&
+      config.terminalMultiplexer !== 'herdr'
     ) {
       const { execa } = await import('execa');
       try {

--- a/src/lib/terminal-session.ts
+++ b/src/lib/terminal-session.ts
@@ -9,11 +9,13 @@ import {
   TabConfig,
   TerminalSessionManager,
   isUIAvailable,
+  isCmuxAvailable,
 } from './terminal-session-base.js';
 import { validateSessionConfig } from './schemas.js';
 import { getSessionName } from './paths.js';
 import { TmuxSessionManager } from './terminal-session-tmux.js';
 import { ZellijSessionManager } from './terminal-session-zellij.js';
+import { CmuxSessionManager, assertCmuxReady } from './terminal-session-cmux.js';
 
 // Re-export for compatibility
 export type { SessionConfig, WindowConfig, TabConfig };
@@ -73,15 +75,47 @@ export function loadSessionConfig(configPath: string): SessionConfig {
 }
 
 /**
- * Get appropriate session manager based on config
+ * Get appropriate session manager based on config.
+ * Single dispatch site - sync.ts reuses this instead of duplicating the ternary.
  */
-function getSessionManager(config: GhwtConfig, verbose = false): TerminalSessionManager {
-  const multiplexer = config.terminalMultiplexer || 'tmux';
+export function getSessionManager(config: GhwtConfig, verbose = false): TerminalSessionManager {
+  switch (config.terminalMultiplexer || 'tmux') {
+    case 'zellij':
+      return new ZellijSessionManager(config, verbose);
+    case 'cmux':
+      return new CmuxSessionManager(config, verbose);
+    default:
+      return new TmuxSessionManager(config, verbose);
+  }
+}
 
-  if (multiplexer === 'zellij') {
-    return new ZellijSessionManager(config, verbose);
-  } else {
-    return new TmuxSessionManager(config, verbose);
+/**
+ * Validate the terminal UI is available, or that cmux is reachable when the
+ * cmux backend is selected (cmux is its own UI, so terminalUI is a no-op).
+ * Throws with an actionable, install hint on failure.
+ */
+async function assertSessionBackendReady(config: GhwtConfig): Promise<void> {
+  if (config.terminalMultiplexer === 'cmux') {
+    const available = await isCmuxAvailable();
+    if (!available) {
+      console.warn(`⚠️  cmux not found in PATH (terminalMultiplexer: 'cmux'). cmux is macOS-only.`);
+      console.warn(`   Install it from https://cmux.com and open the app, then retry.`);
+      throw new Error(`cmux is not available`);
+    }
+    await assertCmuxReady();
+    return;
+  }
+
+  const ui = (config.terminalUI || 'wezterm') as 'wezterm' | 'ghostty' | 'none';
+  const uiAvailable = await isUIAvailable(ui);
+  if (!uiAvailable && ui !== 'none') {
+    console.warn(`⚠️  Terminal UI '${ui}' not found in PATH. Install it first:`);
+    if (ui === 'ghostty') {
+      console.warn(`   brew install ghostty  (or download from https://ghostty.org)`);
+    } else if (ui === 'wezterm') {
+      console.warn(`   brew install wezterm`);
+    }
+    throw new Error(`Terminal UI '${ui}' is not available`);
   }
 }
 
@@ -108,18 +142,8 @@ export async function launchSession(
   const manager = getSessionManager(ghwtConfig, verbose);
 
   try {
-    // Validate UI is available before creating session
-    const ui = (ghwtConfig.terminalUI || 'wezterm') as 'wezterm' | 'ghostty' | 'none';
-    const uiAvailable = await isUIAvailable(ui);
-    if (!uiAvailable && ui !== 'none') {
-      console.warn(`⚠️  Terminal UI '${ui}' not found in PATH. Install it first:`);
-      if (ui === 'ghostty') {
-        console.warn(`   brew install ghostty  (or download from https://ghostty.org)`);
-      } else if (ui === 'wezterm') {
-        console.warn(`   brew install wezterm`);
-      }
-      throw new Error(`Terminal UI '${ui}' is not available`);
-    }
+    // Validate backend (UI app, or cmux reachability + version floor)
+    await assertSessionBackendReady(ghwtConfig);
 
     // Create session with optional note path for template substitution
     await manager.createSession(sessionName, config, worktreePath, project, branch, notePath);
@@ -180,22 +204,17 @@ export async function attachCommand(
       console.log(`✅ Created session: ${sessionName}`);
     }
 
-    // Validate UI is available
-    const ui = (config.terminalUI || 'wezterm') as 'wezterm' | 'ghostty' | 'none';
-    const uiAvailable = await isUIAvailable(ui);
-    if (!uiAvailable && ui !== 'none') {
-      console.warn(`⚠️  Terminal UI '${ui}' not found in PATH. Install it first:`);
-      if (ui === 'ghostty') {
-        console.warn(`   brew install ghostty  (or download from https://ghostty.org)`);
-      } else if (ui === 'wezterm') {
-        console.warn(`   brew install wezterm`);
-      }
-      throw new Error(`Terminal UI '${ui}' is not available`);
-    }
+    // Validate backend (UI app, or cmux reachability + version floor)
+    await assertSessionBackendReady(config);
 
-    // Handle UI app mode for tmux (detach other clients first)
-    if ((ui === 'wezterm' || ui === 'ghostty') && config.terminalMultiplexer !== 'zellij') {
-      // For tmux with UI app: detach other clients before attaching
+    // Handle UI app mode for tmux (detach other clients first).
+    // cmux/zellij manage their own attach; only tmux needs a client detach.
+    const ui = (config.terminalUI || 'wezterm') as 'wezterm' | 'ghostty' | 'none';
+    if (
+      (ui === 'wezterm' || ui === 'ghostty') &&
+      config.terminalMultiplexer !== 'zellij' &&
+      config.terminalMultiplexer !== 'cmux'
+    ) {
       const { execa } = await import('execa');
       try {
         await execa('tmux', ['detach-client', '-s', sessionName]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface GhwtConfig {
   syncInterval: number | null;
   obsidianVaultName?: string;
   shellCommandExecuteId?: string;
-  terminalMultiplexer?: 'tmux' | 'zellij';
+  terminalMultiplexer?: 'tmux' | 'zellij' | 'cmux';
   terminalUI?: 'wezterm' | 'ghostty' | 'none';
   zellijSessionsDir?: string;
   setupPreCommitHooks?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,11 +6,18 @@ export interface GhwtConfig {
   syncInterval: number | null;
   obsidianVaultName?: string;
   shellCommandExecuteId?: string;
-  terminalMultiplexer?: 'tmux' | 'zellij' | 'cmux';
+  terminalMultiplexer?: 'tmux' | 'zellij' | 'cmux' | 'herdr';
   terminalUI?: 'wezterm' | 'ghostty' | 'none';
   zellijSessionsDir?: string;
   setupPreCommitHooks?: boolean;
 }
+
+/**
+ * Live coding-agent state for a session, as reported by an agent-aware
+ * terminal backend (herdr). 'blocked' = agent waiting on the human, which
+ * feeds the needs-attention model.
+ */
+export type AgentStatus = 'idle' | 'working' | 'blocked' | 'done' | 'unknown';
 
 export interface WorktreeMetadata {
   // Auto-synced from git
@@ -48,6 +55,9 @@ export interface WorktreeMetadata {
 
   // Claude session tracking
   claude_session_id?: string;
+
+  // Live agent state (only populated by agent-aware backends, e.g. herdr)
+  agent_status?: AgentStatus;
 
   // Manual/static fields
   project: string;


### PR DESCRIPTION

> Posted by Claude (AI assistant) on jmchilton's behalf.

## Summary

Adds two opt-in terminal-multiplexer backends alongside the existing tmux/zellij defaults:

- **cmux** (macOS-only, fused UI + multiplexer; `terminalUI` no-op; min 0.63.0). Notify bridge rings the workspace only on transitions into needs-attention. Sync hook bridge installs a Claude Code `Stop` hook for `ghwt sync --this`.
- **herdr** (Linux/macOS TUI multiplexer; `terminalUI` honored; min 0.5.10, server must be running). Thinner adapter than cmux (direct workspace+pane ids on create, structured error envelope, real exit codes, no external-access wall). No notify bridge — herdr self-notifies on agent state.

Also wires per-pane **agent_status** (idle/working/blocked/done/unknown) into the needs-attention model — `agent_status === 'blocked'` now flags a worktree and is rendered in the dashboard Dataview. Fetched once per bulk sync, authoritative on success (empty map clears stale state; `null` on failure leaves it untouched, no mass-wipe on a transient outage). No-op for non-agent-aware backends.

Arms-length integration via the `cmux`/`herdr` CLIs only — shelling out to separate binaries is not linking and does not affect ghwt's MIT license.

## Commits

- `ea2e366` cmux integration (session backend + notify/hook bridges)
- `f3602c9` cmux backend pane model + hardened exec (validated vs real cmux)
- `f516436` herdr session backend + agent_status needs-attention signal

## Test plan

- [x] `npm run lint` clean
- [x] `npm run format` clean
- [x] herdr unit tests pass (25 tests, mocked execa)
- [x] attention unit tests pass (14 tests, including new agent_status cases)
- [x] Full vitest run: only the pre-existing `worktree-list` failures remain (unrelated)
- [ ] Manual: `terminalMultiplexer: "herdr"` end-to-end with `ghwt new`/`sync`/`attach`
- [ ] Manual: `terminalMultiplexer: "cmux"` end-to-end on macOS
- [ ] Manual: dashboard renders `agent_status` column and `blocked` flags the worktree