### PR TITLE
fix(rm): resolve bare PR number to pr/<n>, fail loudly when worktree missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.10.6",
         "@types/prompt-sync": "^4.2.3",
-        "@vitest/coverage-v8": "^4.0.6",
+        "@vitest/coverage-v8": "^3.2.7",
         "@vitest/ui": "^3.2.4",
         "eslint": "^9.39.0",
         "eslint-config-prettier": "^10.1.8",
@@ -40,6 +40,20 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -65,9 +79,9 @@
       "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -75,9 +89,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -85,13 +99,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -101,14 +115,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -773,6 +787,130 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1010,6 +1148,17 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -2290,72 +2439,37 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.10.tgz",
-      "integrity": "sha512-g+brmtoKa/sAeIohNJnnWhnHtU6GuqqVOSQ4SxDIPcgZWZyhJs5RmF5LpqXs8Kq64lANP+vnbn5JLzhLj/G56g==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.7.tgz",
+      "integrity": "sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.10",
-        "ast-v8-to-istanbul": "^0.3.8",
-        "debug": "^4.4.3",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-lib-source-maps": "^5.0.6",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.10",
-        "vitest": "4.0.10"
+        "@vitest/browser": "3.2.7",
+        "vitest": "3.2.7"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.10.tgz",
-      "integrity": "sha512-99EQbpa/zuDnvVjthwz5bH9o8iPefoQZ63WV8+bsRJZNw3qQSvSltfut8yu1Jc9mqOYi7pEbsKxYTi/rjaq6PA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.10.tgz",
-      "integrity": "sha512-kOuqWnEwZNtQxMKg3WmPK1vmhZu9WcoX69iwWjVz+jvKTsF1emzsv3eoPcDr6ykA3qP2bsCQE7CwqfNtAVzsmg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.0.10",
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -3353,6 +3467,13 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3932,6 +4053,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -4070,6 +4208,28 @@
         "traverse": "0.6.8"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4081,6 +4241,32 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -4563,6 +4749,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/java-properties": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
@@ -4815,15 +5017,15 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
-      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
-        "source-map-js": "^1.2.1"
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/make-asynchronous": {
@@ -5013,6 +5215,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mrmime": {
@@ -8039,6 +8251,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8150,6 +8369,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-type": {
@@ -9282,10 +9518,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9430,6 +9696,60 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/thenify": {
@@ -10103,6 +10423,25 @@
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.10.6",
     "@types/prompt-sync": "^4.2.3",
-    "@vitest/coverage-v8": "^4.0.6",
+    "@vitest/coverage-v8": "^3.2.7",
     "@vitest/ui": "^3.2.4",
     "eslint": "^9.39.0",
     "eslint-config-prettier": "^10.1.8",

--- a/src/__tests__/commands/create.integration.test.ts
+++ b/src/__tests__/commands/create.integration.test.ts
@@ -118,7 +118,7 @@ describe('create command: base branch selection', () => {
     mkdirSync(repoPath, { recursive: true });
 
     // Initialize git repo
-    await execa('git', ['init'], { cwd: repoPath });
+    await execa('git', ['init', '-b', 'main'], { cwd: repoPath });
     await execa('git', ['config', 'user.email', 'test@example.com'], { cwd: repoPath });
     await execa('git', ['config', 'user.name', 'Test User'], { cwd: repoPath });
 

--- a/src/__tests__/commands/rm.integration.test.ts
+++ b/src/__tests__/commands/rm.integration.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execa } from 'execa';
+import { rmCommand } from '../../commands/rm.js';
+
+/**
+ * `rm` accepts the same branch argument as `create`: a bare PR number, or a bare
+ * branch name. Regression coverage for a bare number resolving to branch/<n>
+ * instead of pr/<n> -- which silently removed nothing while still archiving the note.
+ */
+describe('rm command: branch argument resolution', () => {
+  let testRoot: string;
+  let worktreesDir: string;
+  let noteDir: string;
+  let archiveDir: string;
+
+  const noteFor = (name: string) => join(noteDir, `${name}.md`);
+
+  beforeEach(async () => {
+    testRoot = mkdtemp();
+    worktreesDir = join(testRoot, 'worktrees');
+    noteDir = join(testRoot, 'vault', 'projects', 'galaxy', 'worktrees');
+    archiveDir = join(testRoot, 'old');
+
+    // Worktrees for a PR and a plain branch
+    mkdirSync(join(worktreesDir, 'galaxy', 'pr', '1234'), { recursive: true });
+    mkdirSync(join(worktreesDir, 'galaxy', 'branch', 'cool-feature'), { recursive: true });
+
+    // Notes alongside them
+    mkdirSync(noteDir, { recursive: true });
+    writeFileSync(noteFor('1234'), '# PR 1234');
+    writeFileSync(noteFor('cool-feature'), '# cool-feature');
+
+    // A real repo so `git worktree prune` has somewhere to run
+    const repoPath = join(testRoot, 'repositories', 'galaxy');
+    mkdirSync(repoPath, { recursive: true });
+    await execa('git', ['init'], { cwd: repoPath });
+
+    const configPath = join(testRoot, '.ghwtrc.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        projectsRoot: testRoot,
+        repositoriesDir: 'repositories',
+        worktreesDir: 'worktrees',
+        vaultPath: join(testRoot, 'vault'),
+        obsidianVaultName: 'test-vault',
+        terminalMultiplexer: 'tmux',
+        syncInterval: null,
+      }),
+    );
+    process.env.GHWT_CONFIG = configPath;
+  });
+
+  afterEach(() => {
+    delete process.env.GHWT_CONFIG;
+    vi.restoreAllMocks();
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it('removes pr/<n> when given a bare PR number', async () => {
+    await rmCommand('galaxy', '1234');
+
+    expect(existsSync(join(worktreesDir, 'galaxy', 'pr', '1234'))).toBe(false);
+    expect(existsSync(noteFor('1234'))).toBe(false);
+    expect(existsSync(join(archiveDir, 'galaxy-pr-1234.md'))).toBe(true);
+  });
+
+  it('removes branch/<name> when given a bare branch name', async () => {
+    await rmCommand('galaxy', 'cool-feature');
+
+    expect(existsSync(join(worktreesDir, 'galaxy', 'branch', 'cool-feature'))).toBe(false);
+    expect(existsSync(noteFor('cool-feature'))).toBe(false);
+  });
+
+  it('still accepts an explicit pr/ prefix', async () => {
+    await rmCommand('galaxy', 'pr/1234');
+
+    expect(existsSync(join(worktreesDir, 'galaxy', 'pr', '1234'))).toBe(false);
+  });
+
+  it('does not touch the unrelated branch worktree when removing a PR', async () => {
+    await rmCommand('galaxy', '1234');
+
+    expect(existsSync(join(worktreesDir, 'galaxy', 'branch', 'cool-feature'))).toBe(true);
+    expect(existsSync(noteFor('cool-feature'))).toBe(true);
+  });
+
+  it('exits nonzero and leaves the note in place when the worktree is missing', async () => {
+    const exit = vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit(${code})`);
+    });
+
+    await expect(rmCommand('galaxy', '9999')).rejects.toThrow('process.exit(1)');
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('does not archive the note when the worktree is missing', async () => {
+    writeFileSync(noteFor('9999'), '# PR 9999');
+    vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit(${code})`);
+    });
+
+    await expect(rmCommand('galaxy', '9999')).rejects.toThrow();
+
+    expect(existsSync(noteFor('9999'))).toBe(true);
+    expect(existsSync(join(archiveDir, 'galaxy-9999.md'))).toBe(false);
+  });
+});
+
+function mkdtemp(): string {
+  const dir = join(tmpdir(), `ghwt-rm-test-${process.pid}-${counter++}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+let counter = 0;

--- a/src/__tests__/commands/rm.integration.test.ts
+++ b/src/__tests__/commands/rm.integration.test.ts
@@ -36,7 +36,7 @@ describe('rm command: branch argument resolution', () => {
     // A real repo so `git worktree prune` has somewhere to run
     const repoPath = join(testRoot, 'repositories', 'galaxy');
     mkdirSync(repoPath, { recursive: true });
-    await execa('git', ['init'], { cwd: repoPath });
+    await execa('git', ['init', '-b', 'main'], { cwd: repoPath });
 
     const configPath = join(testRoot, '.ghwtrc.json');
     writeFileSync(

--- a/src/__tests__/integration.integration.test.ts
+++ b/src/__tests__/integration.integration.test.ts
@@ -65,7 +65,7 @@ describe('Integration: Create → List → Remove workflow', () => {
     mkdirSync(repoPath, { recursive: true });
 
     // Initialize bare git repo
-    await execa('git', ['init', '--bare', repoPath]);
+    await execa('git', ['init', '--bare', '-b', 'main', repoPath]);
 
     // Create a temporary clone to set up initial content
     const tmpClone = mkdtempSync(join(tmpdir(), 'clone-'));
@@ -110,13 +110,13 @@ describe('Integration: Create → List → Remove workflow', () => {
 
     try {
       // Create and check out the branch in the worktree
-      await execa('git', ['init'], { cwd: worktreePath });
+      await execa('git', ['init', '-b', 'main'], { cwd: worktreePath });
       await execa('git', ['remote', 'add', 'origin', repoPath], { cwd: worktreePath });
       await execa('git', ['fetch', 'origin'], { cwd: worktreePath });
       await execa('git', ['checkout', '-b', branchName, 'origin/main'], { cwd: worktreePath });
     } catch {
       // Fallback: just ensure directory exists with git repo
-      await execa('git', ['init'], { cwd: worktreePath });
+      await execa('git', ['init', '-b', 'main'], { cwd: worktreePath });
     }
 
     return worktreePath;

--- a/src/__tests__/lib/worktree-list.unit.test.ts
+++ b/src/__tests__/lib/worktree-list.unit.test.ts
@@ -5,6 +5,16 @@ import { tmpdir } from 'os';
 import { listWorktrees, resolveBranch } from '../../lib/worktree-list.js';
 import { writeFileSync } from 'fs';
 
+/**
+ * listWorktrees only counts real git worktrees, which git marks with a `.git`
+ * *file* (a gitdir pointer) rather than a `.git` directory. A bare mkdir is not
+ * discoverable.
+ */
+function makeWorktree(path: string): void {
+  mkdirSync(path, { recursive: true });
+  writeFileSync(join(path, '.git'), `gitdir: ${join(path, '.git-dir')}\n`);
+}
+
 describe('worktree-list', () => {
   it('listWorktrees discovers worktrees in hierarchical structure', () => {
     // Create temporary directory structure
@@ -13,15 +23,9 @@ describe('worktree-list', () => {
 
     try {
       // Create test worktree structure
-      mkdirSync(join(worktreesDir, 'galaxy', 'branch', 'cool-feature'), {
-        recursive: true,
-      });
-      mkdirSync(join(worktreesDir, 'galaxy', 'pr', '1234'), {
-        recursive: true,
-      });
-      mkdirSync(join(worktreesDir, 'gxformat2', 'branch', 'test-branch'), {
-        recursive: true,
-      });
+      makeWorktree(join(worktreesDir, 'galaxy', 'branch', 'cool-feature'));
+      makeWorktree(join(worktreesDir, 'galaxy', 'pr', '1234'));
+      makeWorktree(join(worktreesDir, 'gxformat2', 'branch', 'test-branch'));
 
       // Set GHWT_CONFIG to point to test root
       const configPath = join(testRoot, '.ghwtrc.json');
@@ -203,12 +207,8 @@ describe('worktree-list', () => {
 
     try {
       // Create worktrees for multiple projects
-      mkdirSync(join(worktreesDir, 'galaxy', 'branch', 'feature'), {
-        recursive: true,
-      });
-      mkdirSync(join(worktreesDir, 'gxformat2', 'branch', 'feature'), {
-        recursive: true,
-      });
+      makeWorktree(join(worktreesDir, 'galaxy', 'branch', 'feature'));
+      makeWorktree(join(worktreesDir, 'gxformat2', 'branch', 'feature'));
 
       const configPath = join(testRoot, '.ghwtrc.json');
       writeFileSync(

--- a/src/__tests__/path-commands.integration.test.ts
+++ b/src/__tests__/path-commands.integration.test.ts
@@ -95,7 +95,7 @@ describe('path commands: pathCiArtifactsCommand and pathNoteCommand', () => {
   async function setupTestRepo(projectName: string): Promise<string> {
     const repoPath = join(projectsRoot, 'repositories', projectName);
     mkdirSync(repoPath, { recursive: true });
-    await execa('git', ['init', '--bare', repoPath]);
+    await execa('git', ['init', '--bare', '-b', 'main', repoPath]);
 
     const tmpClone = mkdtempSync(join(tmpdir(), 'clone-'));
     const tmpCloneCwd = process.cwd();
@@ -136,12 +136,12 @@ describe('path commands: pathCiArtifactsCommand and pathNoteCommand', () => {
     const branchName = branchType === 'pr' ? `pr-${name}` : name;
 
     try {
-      await execa('git', ['init'], { cwd: worktreePath });
+      await execa('git', ['init', '-b', 'main'], { cwd: worktreePath });
       await execa('git', ['remote', 'add', 'origin', repoPath], { cwd: worktreePath });
       await execa('git', ['fetch', 'origin'], { cwd: worktreePath });
       await execa('git', ['checkout', '-b', branchName, 'origin/main'], { cwd: worktreePath });
     } catch {
-      await execa('git', ['init'], { cwd: worktreePath });
+      await execa('git', ['init', '-b', 'main'], { cwd: worktreePath });
     }
 
     return worktreePath;

--- a/src/__tests__/this-flag.integration.test.ts
+++ b/src/__tests__/this-flag.integration.test.ts
@@ -75,7 +75,7 @@ describe('--this flag: getCurrentWorktreeContext', () => {
   async function setupTestRepo(projectName: string): Promise<string> {
     const repoPath = join(reposRoot, projectName);
     mkdirSync(repoPath, { recursive: true });
-    await execa('git', ['init', '--bare', repoPath]);
+    await execa('git', ['init', '--bare', '-b', 'main', repoPath]);
 
     const tmpClone = mkdtempSync(join(tmpdir(), 'clone-'));
     const tmpCloneCwd = process.cwd();
@@ -116,12 +116,12 @@ describe('--this flag: getCurrentWorktreeContext', () => {
     const branchName = branchType === 'pr' ? `pr-${name}` : name;
 
     try {
-      await execa('git', ['init'], { cwd: worktreePath });
+      await execa('git', ['init', '-b', 'main'], { cwd: worktreePath });
       await execa('git', ['remote', 'add', 'origin', repoPath], { cwd: worktreePath });
       await execa('git', ['fetch', 'origin'], { cwd: worktreePath });
       await execa('git', ['checkout', '-b', branchName, 'origin/main'], { cwd: worktreePath });
     } catch {
-      await execa('git', ['init'], { cwd: worktreePath });
+      await execa('git', ['init', '-b', 'main'], { cwd: worktreePath });
     }
 
     return worktreePath;

--- a/src/commands/rm.ts
+++ b/src/commands/rm.ts
@@ -3,6 +3,8 @@ import { existsSync, rmSync, mkdirSync, cpSync } from 'fs';
 import { execa } from 'execa';
 import { killSession } from '../lib/terminal-session.js';
 import { pickWorktree } from '../lib/worktree-picker.js';
+import { resolveBranch } from '../lib/worktree-list.js';
+import { assertWorktreeExists } from '../lib/errors.js';
 import {
   loadProjectPaths,
   getWorktreePath,
@@ -23,6 +25,10 @@ export async function rmCommand(
     const picked = await pickWorktree(project);
     project = picked.project;
     branch = picked.branch;
+  } else {
+    // Resolve branch to get the full reference with type prefix, so a bare PR
+    // number lands on pr/<n> rather than the branch/ fallback
+    branch = resolveBranch(project, branch);
   }
 
   const { config, projectsRoot, reposRoot, vaultRoot } = loadProjectPaths();
@@ -44,18 +50,17 @@ export async function rmCommand(
     console.log(`⚠️  Terminal session not found: ${sessionName}`);
   }
 
-  // Check if worktree exists
-  if (!existsSync(worktreePath)) {
-    console.log(`⚠️  Worktree not found: ${worktreePath}`);
-  } else {
-    // Remove worktree
-    try {
-      rmSync(worktreePath, { recursive: true, force: true });
-      console.log(`✅ Deleted worktree: ${worktreePath}`);
-    } catch (error) {
-      console.error(`❌ Failed to delete worktree: ${error}`);
-      throw error;
-    }
+  // Bail out before the note is archived - a missing worktree means the argument
+  // did not name anything, not that there is nothing left to do
+  assertWorktreeExists(worktreePath);
+
+  // Remove worktree
+  try {
+    rmSync(worktreePath, { recursive: true, force: true });
+    console.log(`✅ Deleted worktree: ${worktreePath}`);
+  } catch (error) {
+    console.error(`❌ Failed to delete worktree: ${error}`);
+    throw error;
   }
 
   // Prune repository


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on jmchilton's behalf — not authored by them personally.**

## The bug

`ghwt rm galaxy 22484` silently removes nothing and reports success.

`rm` resolves its branch argument with `parseBranchFromOldFormat`, whose no-prefix
fallthrough returns `{ branchType: 'branch' }`. A bare PR number therefore resolves to
`worktrees/galaxy/branch/22484`, which never exists.

That inverts the contract against `create`, which uses `parseBranchArg`: all-digits →
`pr`, and a `pr/` prefix is *rejected* as old format. So the two commands disagree on the
same argument — `create galaxy 22484` works, `rm galaxy 22484` doesn't, and
`rm galaxy pr/22484` works while `create galaxy pr/22484` hard-errors.

Two things make the miss dangerous rather than merely annoying:

1. **It reports success.** Not-found only logged `⚠️  Worktree not found`, fell through
   to an unconditional `✅ Done! Worktree removed`, and exited 0. Scripted callers can't
   tell the difference.
2. **The note gets archived anyway.** Note archival keys on `getNotePath` →
   `getNoteFileName`, which *strips* the type prefix — so `22484` and `pr/22484` map to
   the same `worktrees/22484.md`. The lookup that failed and the side effect that
   succeeded use different path functions. Result: the note is moved out of the Obsidian
   vault into `~/projects/old/` while the worktree it documents is still on disk.

Found by an agent following documented usage (`ghwt rm galaxy <PR_NUMBER>`) across a
batch of stale worktrees: six "successful" removals, zero worktrees deleted, three notes
displaced from the vault.

## The fix (`d83cab9`)

`rm` was the only worktree-targeting command not calling `resolveBranch` —
`code`, `attach`, `attach-pr`, `claude`, `cursor`, `gh`, `note`, `path-note`,
`path-ci-artifacts`, `ci-artifacts-*` all already do. So this reuses what's there rather
than adding anything:

- `resolveBranch(project, branch)` for CLI-supplied args, matching `code.ts`'s structure
  (picker output is already prefixed, and `resolveBranch` passes prefixed input through).
- `assertWorktreeExists(worktreePath)` from `lib/errors.ts` in place of the warn-and-continue
  block — exits 1 with a clear message *before* the archive step runs.

New `src/__tests__/commands/rm.integration.test.ts` — 6 cases over a temp root wired via
`GHWT_CONFIG`, driving `rmCommand` directly. Red → green:

| test | before | after |
|---|---|---|
| removes `pr/<n>` from a bare PR number | ❌ | ✅ |
| removes `branch/<name>` from a bare branch name | ✅ | ✅ |
| still accepts an explicit `pr/` prefix | ✅ | ✅ |
| leaves the unrelated branch worktree alone | ✅ | ✅ |
| exits nonzero when the worktree is missing | ❌ | ✅ |
| does not archive the note when the worktree is missing | ❌ | ✅ |

## Unrelated CI repairs

The Test workflow was already red on `main` before this branch — three independent
pre-existing breaks, each verified to reproduce on `43db190` with no other changes. They
had to be fixed for this PR to show a meaningful signal. **Split them out if you'd rather
review them separately** — they're isolated commits and touch nothing `rm` depends on.

- **`316f7d7`** — `@vitest/coverage-v8` was on `^4.0.6` against `vitest@^3.2.4`. The v4
  provider declares peer `vitest: 4.0.10` and calls `this.isIncluded`, absent in v3, so
  `test:coverage` died with `TypeError: this.isIncluded is not a function` in
  `convertCoverage` *after* the tests passed. Pinned to the v3 line (3.2.7).

- **`7a3e9ae`** — two `listWorktrees` fixtures built plain directories with `mkdirSync`,
  but `isGitWorktree` requires a `.git` *file* (the gitdir pointer git writes for a real
  worktree). Discovery correctly returned 0. The implementation is right and the fixtures
  weren't worktrees, so the fixtures now write a `.git` pointer — no assertions relaxed.

- **`9269789`** — fixtures ran bare `git init` / `git init --bare` and then referenced
  `main` by name (`git checkout main`, `git push origin main`). That holds only where
  `init.defaultBranch=main` is configured — true locally, not on the runners, where 34
  tests failed with `pathspec 'main' did not match any file(s)`. Every init the fixtures
  later name now passes `-b main`. Reproducible locally via `GIT_CONFIG_GLOBAL` pointing
  at a config with `init.defaultBranch=master`.

Result: **123/123 passing**, verified under both git configurations. `npm run lint`
(eslint + `tsc --noEmit`) and prettier clean.

## Not fixed here

`clean-session.ts` and `sync.ts` also take user-supplied branch args through
`parseBranchFromOldFormat` without `resolveBranch`, so they likely mishandle a bare PR
number the same way. Left out to keep this diff focused on the destructive one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)