### PR TITLE
feat(create): gate editor launch behind an editor config key, default none

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@ Edit `~/.ghwtrc.json`:
   "syncInterval": null,
   "defaultBaseBranch": "dev",
   "terminalMultiplexer": "tmux",
-  "terminalUI": "wezterm"
+  "terminalUI": "wezterm",
+  "editor": "none"
 }
 ```
 
@@ -302,6 +303,15 @@ Edit `~/.ghwtrc.json`:
 - `terminalUI`: `"wezterm"` (default) or `"none"` - How to launch sessions
   - `"wezterm"`: Launch WezTerm with multiplexer inside (modern UI)
   - `"none"`: Launch multiplexer directly (native zellij UI or raw tmux)
+
+**Editor Configuration Options:**
+
+- `editor`: `"none"` (default), `"code"`, or `"cursor"` - Which editor `ghwt create` opens on
+  the new worktree
+  - `"none"`: Don't open an editor; run `ghwt code` or `ghwt cursor` when you want one
+  - `"code"`: Open VS Code
+  - `"cursor"`: Open Cursor
+  - Ignored if the chosen editor's CLI isn't on `PATH`
 
 > **Note:** `ci-artifacts-config/` and `terminal-session-config/` directories are automatically resolved relative to `projectsRoot` and do not need to be configured.
 

--- a/src/__tests__/lib/schemas.unit.test.ts
+++ b/src/__tests__/lib/schemas.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { GhwtConfigSchema } from '../../lib/schemas.js';
+
+const MINIMAL_CONFIG = {
+  projectsRoot: '~/projects',
+  vaultPath: '~/vault',
+};
+
+describe('GhwtConfigSchema: editor', () => {
+  it('defaults to none so create does not launch an editor', () => {
+    const parsed = GhwtConfigSchema.parse(MINIMAL_CONFIG);
+    expect(parsed.editor).toBe('none');
+  });
+
+  it('accepts code', () => {
+    const parsed = GhwtConfigSchema.parse({ ...MINIMAL_CONFIG, editor: 'code' });
+    expect(parsed.editor).toBe('code');
+  });
+
+  it('accepts cursor', () => {
+    const parsed = GhwtConfigSchema.parse({ ...MINIMAL_CONFIG, editor: 'cursor' });
+    expect(parsed.editor).toBe('cursor');
+  });
+
+  it('rejects an unknown editor', () => {
+    expect(() => GhwtConfigSchema.parse({ ...MINIMAL_CONFIG, editor: 'vim' })).toThrow();
+  });
+
+  it('leaves the other launch defaults alone', () => {
+    const parsed = GhwtConfigSchema.parse(MINIMAL_CONFIG);
+    expect(parsed.terminalUI).toBe('wezterm');
+    expect(parsed.terminalMultiplexer).toBe('tmux');
+  });
+});

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -24,6 +24,11 @@ import { assertRepoExists } from '../lib/errors.js';
 import { WorktreeMetadata } from '../types.js';
 import { setupPreCommitHooks } from '../lib/pre-commit.js';
 
+const EDITOR_LABELS = {
+  code: 'VS Code',
+  cursor: 'Cursor',
+} as const;
+
 export async function createCommand(
   project: string,
   branchArg: string,
@@ -264,13 +269,13 @@ export async function createCommand(
   console.log(`🪶 Note created: ${notePath}`);
 
   // Open tools
-  const codeAvailable = await commandExists('code');
+  const editor = config.editor ?? 'none';
   const obsidianAvailable = await commandExists('open');
 
-  if (codeAvailable) {
+  if (editor !== 'none' && (await commandExists(editor))) {
     try {
-      await execa('code', [worktreePath]);
-      console.log('💻 Opened in VS Code');
+      await execa(editor, [worktreePath]);
+      console.log(`💻 Opened in ${EDITOR_LABELS[editor]}`);
     } catch {
       // Silently fail if opening fails
     }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -23,6 +23,7 @@ const DEFAULT_CONFIG: GhwtConfig = {
   syncInterval: null,
   terminalMultiplexer: 'tmux',
   terminalUI: 'wezterm',
+  editor: 'none',
 };
 
 export function loadConfig(): GhwtConfig {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -33,6 +33,10 @@ export const GhwtConfigSchema = z
       .enum(['wezterm', 'ghostty', 'none'])
       .default('wezterm')
       .describe('Terminal UI application'),
+    editor: z
+      .enum(['code', 'cursor', 'none'])
+      .default('none')
+      .describe('Editor to open automatically when a worktree is created'),
     obsidianVaultName: z
       .string()
       .optional()

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface GhwtConfig {
   shellCommandExecuteId?: string;
   terminalMultiplexer?: 'tmux' | 'zellij';
   terminalUI?: 'wezterm' | 'ghostty' | 'none';
+  editor?: 'code' | 'cursor' | 'none';
   zellijSessionsDir?: string;
   setupPreCommitHooks?: boolean;
 }


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on jmchilton's behalf — not authored by them personally.**

## Why

`create` opened VS Code on every new worktree whenever `code` happened to be on `PATH`
(`src/commands/create.ts`), with no flag and no config key to stop it.

## What

Adds `editor: "code" | "cursor" | "none"`, following the existing `terminalUI` key exactly
— zod enum with a `.default()`, an entry in `DEFAULT_CONFIG`, and a documented block in the
README config section. Cursor is in the enum because ghwt already ships a `cursor` command,
so a boolean would have left that unreachable from `create`.

**Defaults to `"none"`** — creating a worktree no longer opens an editor unless asked to.

```json
{
  "terminalUI": "wezterm",
  "editor": "none"   // "code" | "cursor" | "none"
}
```

Existing configs need no edit: the key is absent and resolves to `none` through the schema
default. Set `"editor": "code"` to restore the previous behavior. If the chosen editor's
CLI isn't on `PATH` the launch is skipped, as before.

## Behavior change

This flips a default, so anyone relying on the automatic VS Code launch loses it until they
set `"editor": "code"`. Deliberate — per the repo owner, that's acceptable at the current
user count. Not marked `BREAKING CHANGE`, so semantic-release will treat it as a minor bump
rather than a major one; say the word if you'd rather it force a major.

## Scope

`create` also opens Obsidian unconditionally in the same block. Left alone on purpose — it
wasn't what was asked for, and gating it is a separate call.

## Tests

New `src/__tests__/lib/schemas.unit.test.ts` — 5 cases: the default resolves to `none`,
`code`/`cursor` are accepted, an unknown editor is rejected, and the other launch defaults
(`terminalUI`, `terminalMultiplexer`) are unchanged.

Full suite **128/128 passing**; `npm run lint` (eslint + `tsc --noEmit`) clean.

## Noticed, not fixed

`zellijSessionsDir` is declared in the `GhwtConfig` TypeScript interface but missing from
`GhwtConfigSchema`, which is `.strict()` — so a config actually setting it would be rejected
at load. Pre-existing drift, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)